### PR TITLE
Windows Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -51,11 +51,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release
-      - name: Test binary
+      - name: Test binary (Unix)
+        if: runner.os != 'Windows'
         run: ./target/release/pilotty --version
+      - name: Test binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./target/release/pilotty.exe --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,28 +20,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64 (zigbuild for better glibc compatibility)
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive: tar.gz
             npm_arch: linux-x64
+            binary_name: pilotty
             use_zigbuild: true
-          # Linux ARM64 (zigbuild for better glibc compatibility)
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             archive: tar.gz
             npm_arch: linux-arm64
+            binary_name: pilotty
             use_zigbuild: true
-          # macOS x86_64
           - target: x86_64-apple-darwin
             os: macos-latest
             archive: tar.gz
             npm_arch: darwin-x64
-          # macOS ARM64 (Apple Silicon)
+            binary_name: pilotty
           - target: aarch64-apple-darwin
             os: macos-latest
             archive: tar.gz
             npm_arch: darwin-arm64
+            binary_name: pilotty
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+            npm_arch: win32-x64
+            binary_name: pilotty.exe
 
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +59,6 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      # Install cargo-zigbuild for Linux targets (better glibc compatibility)
       - name: Install cargo-zigbuild
         if: matrix.use_zigbuild
         run: |
@@ -65,15 +69,22 @@ jobs:
         if: matrix.use_zigbuild
         run: cargo zigbuild --release --target ${{ matrix.target }}
 
-      - name: Build with cargo (macOS)
+      - name: Build with cargo (non-Linux)
         if: ${{ !matrix.use_zigbuild }}
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Package for GitHub Release
+      - name: Package for GitHub Release (Unix)
+        if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
-          tar -czvf ../../../pilotty-${{ matrix.target }}.${{ matrix.archive }} pilotty
+          tar -czvf ../../../pilotty-${{ matrix.target }}.${{ matrix.archive }} ${{ matrix.binary_name }}
           cd ../../..
+
+      - name: Package for GitHub Release (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path target/${{ matrix.target }}/release/${{ matrix.binary_name }} -DestinationPath pilotty-${{ matrix.target }}.${{ matrix.archive }}
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
@@ -81,12 +92,11 @@ jobs:
           name: pilotty-${{ matrix.target }}
           path: pilotty-${{ matrix.target }}.${{ matrix.archive }}
 
-      # Also upload the raw binary for npm packaging
       - name: Upload npm binary
         uses: actions/upload-artifact@v4
         with:
           name: npm-${{ matrix.npm_arch }}
-          path: target/${{ matrix.target }}/release/pilotty
+          path: target/${{ matrix.target }}/release/${{ matrix.binary_name }}
 
   verify-binaries:
     name: Verify Binaries
@@ -103,37 +113,37 @@ jobs:
           echo "=== Artifact structure ==="
           find artifacts -type f | head -20
 
-          # Expected release tarballs
-          EXPECTED_TARBALLS=(
+          EXPECTED_RELEASES=(
             "pilotty-x86_64-unknown-linux-gnu/pilotty-x86_64-unknown-linux-gnu.tar.gz"
             "pilotty-aarch64-unknown-linux-gnu/pilotty-aarch64-unknown-linux-gnu.tar.gz"
             "pilotty-x86_64-apple-darwin/pilotty-x86_64-apple-darwin.tar.gz"
             "pilotty-aarch64-apple-darwin/pilotty-aarch64-apple-darwin.tar.gz"
+            "pilotty-x86_64-pc-windows-msvc/pilotty-x86_64-pc-windows-msvc.zip"
           )
 
-          # Expected npm binaries
           EXPECTED_NPM=(
             "npm-linux-x64/pilotty"
             "npm-linux-arm64/pilotty"
             "npm-darwin-x64/pilotty"
             "npm-darwin-arm64/pilotty"
+            "npm-win32-x64/pilotty.exe"
           )
 
-          MIN_TARBALL_SIZE=100000  # 100KB minimum for tarballs
-          MIN_BINARY_SIZE=100000   # 100KB minimum for raw binaries
+          MIN_RELEASE_SIZE=100000
+          MIN_BINARY_SIZE=100000
           ERRORS=0
 
           echo ""
-          echo "=== Checking release tarballs ==="
-          for tarball in "${EXPECTED_TARBALLS[@]}"; do
-            path="artifacts/$tarball"
+          echo "=== Checking release archives ==="
+          for artifact in "${EXPECTED_RELEASES[@]}"; do
+            path="artifacts/$artifact"
             if [ ! -f "$path" ]; then
               echo "ERROR: Missing $path"
               ERRORS=$((ERRORS + 1))
             else
               SIZE=$(stat -c%s "$path" 2>/dev/null || stat -f%z "$path")
-              if [ "$SIZE" -lt "$MIN_TARBALL_SIZE" ]; then
-                echo "ERROR: $path is too small ($SIZE bytes, expected >= $MIN_TARBALL_SIZE)"
+              if [ "$SIZE" -lt "$MIN_RELEASE_SIZE" ]; then
+                echo "ERROR: $path is too small ($SIZE bytes, expected >= $MIN_RELEASE_SIZE)"
                 ERRORS=$((ERRORS + 1))
               else
                 echo "OK: $path ($SIZE bytes)"
@@ -143,8 +153,8 @@ jobs:
 
           echo ""
           echo "=== Checking npm binaries ==="
-          for binary in "${EXPECTED_NPM[@]}"; do
-            path="artifacts/$binary"
+          for artifact in "${EXPECTED_NPM[@]}"; do
+            path="artifacts/$artifact"
             if [ ! -f "$path" ]; then
               echo "ERROR: Missing $path"
               ERRORS=$((ERRORS + 1))
@@ -164,7 +174,7 @@ jobs:
             echo "FAILED: $ERRORS artifact issues found"
             exit 1
           fi
-          echo "SUCCESS: All 4 release tarballs and 4 npm binaries present and valid"
+          echo "SUCCESS: All 5 release archives and 5 npm binaries present and valid"
 
   release:
     name: Create Release
@@ -213,12 +223,14 @@ jobs:
       - name: Prepare npm package
         run: |
           cd npm/bin
-          # Flatten directory structure and rename binaries
-          # Each artifact is in npm-{os}-{arch}/pilotty
           for dir in npm-*/; do
             arch=$(basename "$dir" | sed 's/npm-//')
-            mv "$dir/pilotty" "pilotty-${arch}"
-            chmod +x "pilotty-${arch}"
+            if [ -f "$dir/pilotty.exe" ]; then
+              mv "$dir/pilotty.exe" "pilotty-${arch}.exe"
+            else
+              mv "$dir/pilotty" "pilotty-${arch}"
+              chmod +x "pilotty-${arch}"
+            fi
             rmdir "$dir"
           done
           ls -la

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "vt100",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ unicode-width = "0.2"
 # System
 libc = "0.2"
 dirs = "5"
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Windows support currently uses ConPTY-backed sessions plus a loopback TCP transp
 # Spawn a TUI application
 pilotty spawn htop
 
+# Run via your configured/default shell
+pilotty spawn --shell opencode
+
+# Force a specific shell (useful on Windows for Git Bash vs PowerShell)
+pilotty spawn --shell --shell-program bash 'echo from bash'
+
 # Take a snapshot of the terminal
 pilotty snapshot
 
@@ -382,6 +388,17 @@ pilotty stores its endpoint marker at (in priority order):
 4. `/tmp/pilotty/{session}.sock` (last resort)
 
 On Unix this path is the Unix domain socket itself. On Windows it is a marker file that stores the daemon's loopback TCP address, allowing reconnects even if the preferred deterministic port was occupied and pilotty had to fall back to another one.
+
+### Shell selection for `spawn --shell`
+
+When `--shell` is used, pilotty resolves the shell in this order:
+1. `--shell-program`
+2. `PILOTTY_SHELL`
+3. `SHELL`
+4. `COMSPEC` (Windows)
+5. platform fallback
+
+Direct `pilotty spawn <command>` still bypasses the shell entirely and execs the command directly.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Requires [Rust](https://rustup.rs) 1.70+.
 | Linux | arm64 | ✅ |
 | Windows | x64 | ✅ Experimental |
 
-Windows support currently uses pipe-backed sessions plus a loopback TCP transport for daemon communication. It works for shell-oriented automation and command output, but full-screen TUIs should still be treated as experimental.
+Windows support currently uses ConPTY-backed sessions plus a loopback TCP transport for daemon communication. Basic interactive text applications now work substantially better, including cursor-position query/response flows that many modern TUIs rely on. Full-screen TUIs should still be treated as experimental.
 
 ## Quick Start
 
@@ -381,7 +381,7 @@ pilotty stores its endpoint marker at (in priority order):
 3. `~/.pilotty/{session}.sock` (home directory fallback)
 4. `/tmp/pilotty/{session}.sock` (last resort)
 
-On Unix this path is the Unix domain socket itself. On Windows it is a marker file used to derive the loopback TCP port.
+On Unix this path is the Unix domain socket itself. On Windows it is a marker file that stores the daemon's loopback TCP address, allowing reconnects even if the preferred deterministic port was occupied and pilotty had to fall back to another one.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ pilotty enables AI agents to interact with terminal applications through a simpl
 npm install -g pilotty
 ```
 
+This installs the platform-specific native binary for macOS, Linux, or Windows.
+
 ### From Source
 
 ```bash
@@ -69,9 +71,9 @@ Requires [Rust](https://rustup.rs) 1.70+.
 | macOS | arm64 (Apple Silicon) | ✅ |
 | Linux | x64 | ✅ |
 | Linux | arm64 | ✅ |
-| Windows | - | ❌ Not supported |
+| Windows | x64 | ✅ Experimental |
 
-Windows is not supported due to the use of Unix domain sockets and POSIX PTY APIs.
+Windows support currently uses pipe-backed sessions plus a loopback TCP transport for daemon communication. It works for shell-oriented automation and command output, but full-screen TUIs should still be treated as experimental.
 
 ## Quick Start
 
@@ -340,7 +342,7 @@ pilotty spawn --name editor vim
 pilotty uses a daemon architecture similar to agent-browser:
 
 ```
-┌─────────────┐     Unix Socket      ┌─────────────────┐
+┌─────────────┐   Local transport    ┌─────────────────┐
 │   CLI       │ ──────────────────▶  │     Daemon      │
 │  (pilotty)  │     JSON-line        │  (auto-started) │
 └─────────────┘                      └─────────────────┘
@@ -371,13 +373,15 @@ The daemon is designed for zero-maintenance operation:
 
 This means you never need to manually manage the daemon, it starts when needed and stops when idle.
 
-### Socket Location
+### Transport Location
 
-The daemon socket is created at (in priority order):
+pilotty stores its endpoint marker at (in priority order):
 1. `$PILOTTY_SOCKET_DIR/{session}.sock` (explicit override)
 2. `$XDG_RUNTIME_DIR/pilotty/{session}.sock` (Linux standard)
 3. `~/.pilotty/{session}.sock` (home directory fallback)
 4. `/tmp/pilotty/{session}.sock` (last resort)
+
+On Unix this path is the Unix domain socket itself. On Windows it is a marker file used to derive the loopback TCP port.
 
 ## Error Handling
 

--- a/crates/pilotty-cli/Cargo.toml
+++ b/crates/pilotty-cli/Cargo.toml
@@ -27,3 +27,4 @@ chrono = { workspace = true }
 vt100 = { workspace = true }
 regex = { workspace = true }
 dirs = { workspace = true }
+windows-sys = { workspace = true }

--- a/crates/pilotty-cli/src/args.rs
+++ b/crates/pilotty-cli/src/args.rs
@@ -25,7 +25,9 @@ Examples:
   pilotty spawn vim file.txt            # Command with arguments
   pilotty spawn --name editor vim       # Named session for easy reference
   pilotty spawn --cwd /tmp bash         # Start bash in /tmp directory
-  pilotty spawn bash -c 'echo hello'    # Shell command with args")]
+  pilotty spawn bash -c 'echo hello'    # Direct shell command with args
+  pilotty spawn --shell opencode        # Run via configured/default shell
+  pilotty spawn --shell --shell-program bash 'echo $SHELL'  # Force a shell")]
     Spawn(SpawnArgs),
 
     /// Kill a session and its child process
@@ -135,6 +137,21 @@ pub struct SpawnArgs {
     /// Working directory for the spawned process [default: current directory]
     #[arg(long, value_name = "DIR")]
     pub cwd: Option<String>,
+
+    /// Run the command through a shell instead of direct exec.
+    ///
+    /// Shell resolution order:
+    /// 1. --shell-program
+    /// 2. PILOTTY_SHELL
+    /// 3. SHELL
+    /// 4. COMSPEC (Windows)
+    /// 5. platform fallback
+    #[arg(long)]
+    pub shell: bool,
+
+    /// Explicit shell program for --shell (e.g. bash, pwsh, powershell.exe, cmd.exe)
+    #[arg(long, value_name = "PROGRAM")]
+    pub shell_program: Option<String>,
 }
 
 #[derive(Debug, clap::Args)]

--- a/crates/pilotty-cli/src/daemon/client.rs
+++ b/crates/pilotty-cli/src/daemon/client.rs
@@ -7,11 +7,10 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use pilotty_core::protocol::{Request, Response};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::UnixStream;
 use tokio::time::timeout;
 use tracing::{debug, info};
 
-use crate::daemon::paths;
+use crate::daemon::{paths, transport};
 
 /// Maximum time to wait for daemon to start up.
 const DAEMON_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -21,7 +20,7 @@ const RETRY_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Client for communicating with the daemon.
 pub struct DaemonClient {
-    stream: UnixStream,
+    stream: transport::Stream,
 }
 
 impl DaemonClient {
@@ -30,7 +29,7 @@ impl DaemonClient {
         let socket_path = paths::get_socket_path(None);
 
         // Try to connect directly first
-        if let Ok(stream) = UnixStream::connect(&socket_path).await {
+        if let Ok(stream) = transport::connect(&socket_path).await {
             debug!("Connected to existing daemon");
             return Ok(Self { stream });
         }
@@ -48,23 +47,36 @@ impl DaemonClient {
     ///
     /// Returns the child process handle so we can detect early crashes.
     fn start_daemon() -> Result<std::process::Child> {
-        use std::os::unix::process::CommandExt;
-
         let exe = std::env::current_exe().context("Failed to get current executable path")?;
 
-        // Spawn daemon as detached background process.
-        // process_group(0) creates a new process group with the child as leader,
-        // preventing the daemon from receiving SIGHUP when the CLI's terminal closes.
-        let child = std::process::Command::new(exe)
+        // Spawn daemon as a background process.
+        // Unix starts it in a new process group to avoid SIGHUP on parent exit.
+        // Windows starts it in a detached process group without opening a new console.
+        let mut command = std::process::Command::new(exe);
+        command
             .arg("daemon")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .process_group(0)
-            .spawn()
-            .context("Failed to spawn daemon process")?;
+            .stderr(Stdio::null());
 
-        Ok(child)
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+            const DETACHED_PROCESS: u32 = 0x0000_0008;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            command.creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS | CREATE_NO_WINDOW);
+        }
+
+        command
+            .spawn()
+            .context("Failed to spawn daemon process")
     }
 
     /// Wait for the daemon socket to become available.
@@ -74,7 +86,7 @@ impl DaemonClient {
     async fn wait_for_daemon(
         socket_path: &PathBuf,
         mut child: std::process::Child,
-    ) -> Result<UnixStream> {
+    ) -> Result<transport::Stream> {
         let start = std::time::Instant::now();
 
         loop {
@@ -95,7 +107,7 @@ impl DaemonClient {
                 }
             }
 
-            match UnixStream::connect(socket_path).await {
+            match transport::connect(socket_path).await {
                 Ok(stream) => {
                     info!("Connected to daemon after {:?}", start.elapsed());
                     return Ok(stream);
@@ -159,7 +171,7 @@ impl DaemonClient {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(windows)))]
 mod tests {
     use super::*;
     use crate::daemon::server::DaemonServer;
@@ -185,7 +197,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Connect client directly (bypassing auto-start since we're using temp socket)
-        let stream = UnixStream::connect(&socket_path)
+        let stream = crate::daemon::transport::connect(&socket_path)
             .await
             .expect("Failed to connect");
         let mut client = DaemonClient { stream };

--- a/crates/pilotty-cli/src/daemon/client.rs
+++ b/crates/pilotty-cli/src/daemon/client.rs
@@ -5,7 +5,7 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
-use pilotty_core::protocol::{Request, Response};
+use pilotty_core::protocol::{Command, Request, Response};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::time::timeout;
 use tracing::{debug, info};
@@ -18,6 +18,9 @@ const DAEMON_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 /// Interval between socket connection attempts.
 const RETRY_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Timeout for validating an already-running daemon.
+const DAEMON_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+
 /// Client for communicating with the daemon.
 pub struct DaemonClient {
     stream: transport::Stream,
@@ -28,10 +31,16 @@ impl DaemonClient {
     pub async fn connect() -> Result<Self> {
         let socket_path = paths::get_socket_path(None);
 
-        // Try to connect directly first
+        // Try to connect directly first. On Windows the preferred loopback port may
+        // be occupied by some unrelated process, so we validate the endpoint before
+        // trusting it as a live pilotty daemon.
         if let Ok(stream) = transport::connect(&socket_path).await {
-            debug!("Connected to existing daemon");
-            return Ok(Self { stream });
+            let mut client = Self { stream };
+            if client.probe().await {
+                debug!("Connected to existing daemon");
+                return Ok(client);
+            }
+            debug!("Endpoint accepted a connection but did not behave like pilotty; starting a new daemon");
         }
 
         // Daemon not running, start it
@@ -109,8 +118,14 @@ impl DaemonClient {
 
             match transport::connect(socket_path).await {
                 Ok(stream) => {
-                    info!("Connected to daemon after {:?}", start.elapsed());
-                    return Ok(stream);
+                    let mut client = Self { stream };
+                    if client.probe().await {
+                        info!("Connected to daemon after {:?}", start.elapsed());
+                        return Ok(client.stream);
+                    }
+                    debug!(
+                        "Connected endpoint during startup, but it did not behave like pilotty yet"
+                    );
                 }
                 Err(_) => {
                     if start.elapsed() > DAEMON_STARTUP_TIMEOUT {
@@ -120,6 +135,18 @@ impl DaemonClient {
                 }
             }
         }
+    }
+
+    async fn probe(&mut self) -> bool {
+        let request = Request {
+            id: "probe".to_string(),
+            command: Command::ListSessions,
+        };
+
+        self.request_with_timeout(request, DAEMON_PROBE_TIMEOUT)
+            .await
+            .map(|response| response.success)
+            .unwrap_or(false)
     }
 
     /// Send a request and wait for a response.

--- a/crates/pilotty-cli/src/daemon/mod.rs
+++ b/crates/pilotty-cli/src/daemon/mod.rs
@@ -6,3 +6,4 @@ pub mod pty;
 pub mod server;
 pub mod session;
 pub mod terminal;
+pub mod transport;

--- a/crates/pilotty-cli/src/daemon/pty.rs
+++ b/crates/pilotty-cli/src/daemon/pty.rs
@@ -1,14 +1,12 @@
-//! PTY / process session management.
+//! PTY session management using portable-pty.
 
 use std::io::{Read, Write};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
-
-#[cfg(unix)]
-use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 
 /// Terminal size in columns and rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -23,7 +21,6 @@ impl Default for TermSize {
     }
 }
 
-#[cfg(unix)]
 impl From<TermSize> for PtySize {
     fn from(size: TermSize) -> Self {
         PtySize {
@@ -35,206 +32,119 @@ impl From<TermSize> for PtySize {
     }
 }
 
-/// A spawned terminal/process session.
+/// A PTY session wrapping a master PTY and child process.
 pub struct PtySession {
-    size: TermSize,
-    #[cfg(unix)]
     master: Box<dyn MasterPty + Send>,
-    #[cfg(unix)]
     child: Box<dyn Child + Send + Sync>,
-    #[cfg(windows)]
-    reader: Option<Box<dyn Read + Send>>,
-    #[cfg(windows)]
-    writer: Option<Box<dyn Write + Send>>,
-    #[cfg(windows)]
-    child: std::process::Child,
+    size: TermSize,
 }
 
 impl PtySession {
-    /// Spawn a command in a new PTY/session.
+    /// Spawn a command in a new PTY session.
+    ///
+    /// If `cwd` is provided, the command will run in that directory.
+    /// Otherwise, it inherits the daemon's current directory.
     pub fn spawn(command: &[String], size: TermSize, cwd: Option<&str>) -> Result<Self> {
         if command.is_empty() {
             anyhow::bail!("Command cannot be empty");
         }
 
-        #[cfg(unix)]
-        {
-            let pty_system = native_pty_system();
-            let pair = pty_system
-                .openpty(size.into())
-                .context("Failed to open PTY")?;
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(size.into())
+            .context("Failed to open PTY")?;
 
-            let mut cmd = CommandBuilder::new(&command[0]);
-            if command.len() > 1 {
-                cmd.args(&command[1..]);
-            }
-            if let Some(dir) = cwd {
-                cmd.cwd(dir);
-            }
-
-            let child = pair
-                .slave
-                .spawn_command(cmd)
-                .context("Failed to spawn command")?;
-
-            return Ok(Self {
-                size,
-                master: pair.master,
-                child,
-            });
+        let mut cmd = CommandBuilder::new(&command[0]);
+        if command.len() > 1 {
+            cmd.args(&command[1..]);
+        }
+        if let Some(dir) = cwd {
+            cmd.cwd(dir);
         }
 
-        #[cfg(windows)]
-        {
-            let mut cmd = std::process::Command::new(&command[0]);
-            if command.len() > 1 {
-                cmd.args(&command[1..]);
-            }
-            if let Some(dir) = cwd {
-                cmd.current_dir(dir);
-            }
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .context("Failed to spawn command")?;
 
-            cmd.stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::null());
-
-            let mut child = cmd.spawn().context("Failed to spawn command")?;
-            let reader = child
-                .stdout
-                .take()
-                .context("Failed to capture process stdout")?;
-            let writer = child
-                .stdin
-                .take()
-                .context("Failed to capture process stdin")?;
-
-            return Ok(Self {
-                size,
-                reader: Some(Box::new(reader)),
-                writer: Some(Box::new(writer)),
-                child,
-            });
-        }
+        Ok(Self {
+            master: pair.master,
+            child,
+            size,
+        })
     }
 
-    #[cfg(unix)]
+    /// Get a reader for the PTY output.
     pub fn reader(&self) -> Result<Box<dyn Read + Send>> {
         self.master
             .try_clone_reader()
             .context("Failed to clone PTY reader")
     }
 
-    #[cfg(unix)]
+    /// Get a writer for the PTY input.
     pub fn writer(&self) -> Result<Box<dyn Write + Send>> {
         self.master
             .take_writer()
             .context("Failed to take PTY writer")
     }
 
-    #[cfg(windows)]
-    fn take_reader(&mut self) -> Result<Box<dyn Read + Send>> {
-        self.reader
-            .take()
-            .context("Process reader already taken")
-    }
-
-    #[cfg(windows)]
-    fn take_writer(&mut self) -> Result<Box<dyn Write + Send>> {
-        self.writer
-            .take()
-            .context("Process writer already taken")
-    }
-
+    /// Get the current terminal size.
     pub fn size(&self) -> TermSize {
         self.size
     }
 
-    #[cfg(unix)]
-    pub fn into_parts(self) -> (Box<dyn MasterPty + Send>, ManagedChild) {
-        (self.master, ManagedChild::Portable(self.child))
-    }
-
-    #[cfg(windows)]
-    fn into_child(self) -> ManagedChild {
-        ManagedChild::Std(self.child)
+    /// Consume the session and return the master PTY and child process.
+    ///
+    /// Used by AsyncPtyHandle to keep the master for resize operations
+    /// and the child for proper process cleanup on shutdown.
+    pub fn into_parts(self) -> (Box<dyn MasterPty + Send>, Box<dyn Child + Send + Sync>) {
+        (self.master, self.child)
     }
 }
 
-enum ManagedChild {
-    #[cfg(unix)]
-    Portable(Box<dyn Child + Send + Sync>),
-    #[cfg(windows)]
-    Std(std::process::Child),
-}
-
-impl ManagedChild {
-    fn kill(&mut self) -> Result<()> {
-        match self {
-            #[cfg(unix)]
-            Self::Portable(child) => child.kill().context("Failed to kill PTY child"),
-            #[cfg(windows)]
-            Self::Std(child) => child.kill().context("Failed to kill process child"),
-        }
-    }
-
-    fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>> {
-        match self {
-            #[cfg(unix)]
-            Self::Portable(child) => child.try_wait().context("Failed to poll PTY child"),
-            #[cfg(windows)]
-            Self::Std(child) => child.try_wait().context("Failed to poll process child"),
-        }
-    }
-}
-
-/// Buffer size for reading from PTY/process stdout.
+/// Buffer size for reading from PTY.
 const READ_BUFFER_SIZE: usize = 4096;
 
-/// Handle for async terminal/process I/O operations.
+/// Handle for async PTY I/O operations.
+///
+/// Uses tokio channels for async I/O with background threads for the
+/// actual blocking PTY reads/writes.
 pub struct AsyncPtyHandle {
+    /// Sender for writing to PTY stdin.
     write_tx: mpsc::Sender<Vec<u8>>,
+    /// Receiver for reading from PTY stdout.
+    /// Wrapped in Mutex for interior mutability so read() can take &self,
+    /// avoiding the need for &mut self which would require exclusive session access.
     read_rx: tokio::sync::Mutex<mpsc::Receiver<Vec<u8>>>,
+    /// Flag to signal shutdown.
     shutdown: Arc<std::sync::atomic::AtomicBool>,
-    #[cfg(unix)]
+    /// Master PTY for resize operations (sends SIGWINCH).
+    /// Wrapped in Mutex to make AsyncPtyHandle Sync.
     master: std::sync::Mutex<Box<dyn MasterPty + Send>>,
-    child: std::sync::Mutex<ManagedChild>,
+    /// Child process handle for cleanup on shutdown.
+    /// Wrapped in Mutex to allow killing from shutdown().
+    child: std::sync::Mutex<Box<dyn Child + Send + Sync>>,
+    /// Current terminal size, updated on resize.
+    /// Wrapped in Mutex for interior mutability.
     size: std::sync::Mutex<TermSize>,
+    /// Handle to the reader thread for cleanup.
     reader_thread: Option<std::thread::JoinHandle<()>>,
+    /// Handle to the writer thread for cleanup.
     writer_thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl AsyncPtyHandle {
-    /// Create async I/O channels for a PTY/process session.
+    /// Create async I/O channels for a PTY session.
+    ///
+    /// This spawns background threads for reading and writing to the PTY.
     pub fn new(session: PtySession) -> Result<Self> {
-        #[cfg(unix)]
-        {
-            let reader = session.reader()?;
-            let writer = session.writer()?;
-            let initial_size = session.size();
-            let (master, child) = session.into_parts();
-            return Self::new_inner(reader, writer, initial_size, Some(master), child);
-        }
+        let reader = session.reader()?;
+        let writer = session.writer()?;
+        let initial_size = session.size();
+        let (master, child) = session.into_parts();
 
-        #[cfg(windows)]
-        {
-            let mut session = session;
-            let reader = session.take_reader()?;
-            let writer = session.take_writer()?;
-            let initial_size = session.size();
-            let child = session.into_child();
-            return Self::new_inner(reader, writer, initial_size, child);
-        }
-    }
-
-    #[cfg(unix)]
-    fn new_inner(
-        reader: Box<dyn Read + Send>,
-        writer: Box<dyn Write + Send>,
-        initial_size: TermSize,
-        master: Option<Box<dyn MasterPty + Send>>,
-        child: ManagedChild,
-    ) -> Result<Self> {
         let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
         let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(64);
         let (read_tx, read_rx) = mpsc::channel::<Vec<u8>>(64);
 
@@ -251,7 +161,7 @@ impl AsyncPtyHandle {
             write_tx,
             read_rx: tokio::sync::Mutex::new(read_rx),
             shutdown,
-            master: std::sync::Mutex::new(master.context("Missing PTY master")?),
+            master: std::sync::Mutex::new(master),
             child: std::sync::Mutex::new(child),
             size: std::sync::Mutex::new(initial_size),
             reader_thread: Some(reader_thread),
@@ -259,47 +169,13 @@ impl AsyncPtyHandle {
         })
     }
 
-    #[cfg(windows)]
-    fn new_inner(
-        reader: Box<dyn Read + Send>,
-        writer: Box<dyn Write + Send>,
-        initial_size: TermSize,
-        child: ManagedChild,
-    ) -> Result<Self> {
-        let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(64);
-        let (read_tx, read_rx) = mpsc::channel::<Vec<u8>>(64);
-
-        let reader_shutdown = shutdown.clone();
-        let reader_thread = std::thread::spawn(move || {
-            Self::reader_loop(reader, read_tx, reader_shutdown);
-        });
-
-        let writer_thread = std::thread::spawn(move || {
-            Self::writer_loop(writer, write_rx);
-        });
-
-        Ok(Self {
-            write_tx,
-            read_rx: tokio::sync::Mutex::new(read_rx),
-            shutdown,
-            child: std::sync::Mutex::new(child),
-            size: std::sync::Mutex::new(initial_size),
-            reader_thread: Some(reader_thread),
-            writer_thread: Some(writer_thread),
-        })
-    }
-
-    /// Resize the PTY. On Windows pipe-backed sessions this is currently a no-op.
+    /// Resize the PTY and send SIGWINCH / equivalent to the child process.
     pub fn resize(&self, size: TermSize) -> Result<()> {
-        #[cfg(unix)]
-        {
-            self.master
-                .lock()
-                .map_err(|_| anyhow::anyhow!("Master PTY mutex poisoned"))?
-                .resize(size.into())
-                .context("Failed to resize PTY")?;
-        }
+        self.master
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Master PTY mutex poisoned"))?
+            .resize(size.into())
+            .context("Failed to resize PTY")?;
 
         *self
             .size
@@ -308,20 +184,25 @@ impl AsyncPtyHandle {
         Ok(())
     }
 
-    /// Send bytes to stdin.
+    /// Send bytes to the PTY stdin.
     pub async fn write(&self, data: &[u8]) -> Result<()> {
         self.write_tx
             .send(data.to_vec())
             .await
-            .context("Failed to send to input channel")
+            .context("Failed to send to PTY input channel")
     }
 
-    /// Receive bytes from stdout.
+    /// Receive bytes from the PTY stdout.
+    ///
+    /// Returns None if the PTY has closed.
     pub async fn read(&self) -> Option<Vec<u8>> {
         self.read_rx.lock().await.recv().await
     }
 
-    /// Check whether the child has exited.
+    /// Check if the child process has exited without blocking.
+    ///
+    /// Returns `Some(true)` if the process has exited, `Some(false)` if still running,
+    /// or `None` if the mutex is poisoned.
     pub fn has_exited(&self) -> Option<bool> {
         self.child
             .lock()
@@ -330,11 +211,14 @@ impl AsyncPtyHandle {
             .map(|status| status.is_some())
     }
 
-    /// Shutdown async I/O and terminate the child process.
+    /// Shutdown the async PTY I/O and terminate the child process.
     pub async fn shutdown(&self) {
         if let Ok(mut child) = self.child.lock() {
             if let Err(e) = child.kill() {
-                debug!("Failed to kill child process (may have already exited): {}", e);
+                debug!(
+                    "Failed to kill child process (may have already exited): {}",
+                    e
+                );
             }
             if let Err(e) = child.try_wait() {
                 debug!("Failed to collect child exit status: {}", e);
@@ -346,6 +230,7 @@ impl AsyncPtyHandle {
         self.read_rx.lock().await.close();
     }
 
+    /// Reader loop running in a background thread.
     fn reader_loop(
         mut reader: Box<dyn Read + Send>,
         read_tx: mpsc::Sender<Vec<u8>>,
@@ -381,6 +266,7 @@ impl AsyncPtyHandle {
         }
     }
 
+    /// Writer loop running in a background thread.
     fn writer_loop(mut writer: Box<dyn Write + Send>, mut write_rx: mpsc::Receiver<Vec<u8>>) {
         while let Some(data) = write_rx.blocking_recv() {
             if let Err(e) = writer.write_all(&data) {
@@ -400,7 +286,10 @@ impl Drop for AsyncPtyHandle {
     fn drop(&mut self) {
         if let Ok(mut child) = self.child.lock() {
             if let Err(e) = child.kill() {
-                debug!("Failed to kill child on drop (may have already exited): {}", e);
+                debug!(
+                    "Failed to kill child on drop (may have already exited): {}",
+                    e
+                );
             }
             if let Err(e) = child.try_wait() {
                 debug!("Failed to collect child exit status on drop: {}", e);
@@ -412,12 +301,12 @@ impl Drop for AsyncPtyHandle {
 
         if let Some(ref handle) = self.reader_thread {
             if !handle.is_finished() {
-                debug!("PTY reader thread still running on drop, will terminate on close");
+                debug!("PTY reader thread still running on drop, will terminate on PTY close");
             }
         }
         if let Some(ref handle) = self.writer_thread {
             if !handle.is_finished() {
-                debug!("PTY writer thread still running on drop, will terminate on close");
+                debug!("PTY writer thread still running on drop, will terminate on channel close");
             }
         }
     }
@@ -442,6 +331,7 @@ mod tests {
 
         let mut output = vec![0u8; 1024];
         let mut total_read = 0;
+
         std::thread::sleep(Duration::from_millis(100));
 
         loop {
@@ -482,6 +372,7 @@ mod tests {
 
         writer.write_all(b"test input\n").expect("Failed to write");
         writer.flush().expect("Failed to flush");
+
         std::thread::sleep(Duration::from_millis(100));
 
         let mut output = vec![0u8; 256];
@@ -565,6 +456,7 @@ mod tests {
             .expect("Failed to spawn pwd with cwd");
 
         let mut reader = session.reader().expect("Failed to get reader");
+
         std::thread::sleep(Duration::from_millis(100));
 
         let mut output = vec![0u8; 256];

--- a/crates/pilotty-cli/src/daemon/pty.rs
+++ b/crates/pilotty-cli/src/daemon/pty.rs
@@ -1,12 +1,14 @@
-//! PTY session management using portable-pty.
+//! PTY / process session management.
 
 use std::io::{Read, Write};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
+
+#[cfg(unix)]
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 
 /// Terminal size in columns and rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -21,6 +23,7 @@ impl Default for TermSize {
     }
 }
 
+#[cfg(unix)]
 impl From<TermSize> for PtySize {
     fn from(size: TermSize) -> Self {
         PtySize {
@@ -32,129 +35,214 @@ impl From<TermSize> for PtySize {
     }
 }
 
-/// A PTY session wrapping a master PTY and child process.
+/// A spawned terminal/process session.
 pub struct PtySession {
-    master: Box<dyn MasterPty + Send>,
-    child: Box<dyn Child + Send + Sync>,
     size: TermSize,
+    #[cfg(unix)]
+    master: Box<dyn MasterPty + Send>,
+    #[cfg(unix)]
+    child: Box<dyn Child + Send + Sync>,
+    #[cfg(windows)]
+    reader: Option<Box<dyn Read + Send>>,
+    #[cfg(windows)]
+    writer: Option<Box<dyn Write + Send>>,
+    #[cfg(windows)]
+    child: std::process::Child,
 }
 
 impl PtySession {
-    /// Spawn a command in a new PTY session.
-    ///
-    /// If `cwd` is provided, the command will run in that directory.
-    /// Otherwise, it inherits the daemon's current directory.
+    /// Spawn a command in a new PTY/session.
     pub fn spawn(command: &[String], size: TermSize, cwd: Option<&str>) -> Result<Self> {
         if command.is_empty() {
             anyhow::bail!("Command cannot be empty");
         }
 
-        let pty_system = native_pty_system();
-        let pair = pty_system
-            .openpty(size.into())
-            .context("Failed to open PTY")?;
+        #[cfg(unix)]
+        {
+            let pty_system = native_pty_system();
+            let pair = pty_system
+                .openpty(size.into())
+                .context("Failed to open PTY")?;
 
-        let mut cmd = CommandBuilder::new(&command[0]);
-        if command.len() > 1 {
-            cmd.args(&command[1..]);
+            let mut cmd = CommandBuilder::new(&command[0]);
+            if command.len() > 1 {
+                cmd.args(&command[1..]);
+            }
+            if let Some(dir) = cwd {
+                cmd.cwd(dir);
+            }
+
+            let child = pair
+                .slave
+                .spawn_command(cmd)
+                .context("Failed to spawn command")?;
+
+            return Ok(Self {
+                size,
+                master: pair.master,
+                child,
+            });
         }
-        if let Some(dir) = cwd {
-            cmd.cwd(dir);
+
+        #[cfg(windows)]
+        {
+            let mut cmd = std::process::Command::new(&command[0]);
+            if command.len() > 1 {
+                cmd.args(&command[1..]);
+            }
+            if let Some(dir) = cwd {
+                cmd.current_dir(dir);
+            }
+
+            cmd.stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::null());
+
+            let mut child = cmd.spawn().context("Failed to spawn command")?;
+            let reader = child
+                .stdout
+                .take()
+                .context("Failed to capture process stdout")?;
+            let writer = child
+                .stdin
+                .take()
+                .context("Failed to capture process stdin")?;
+
+            return Ok(Self {
+                size,
+                reader: Some(Box::new(reader)),
+                writer: Some(Box::new(writer)),
+                child,
+            });
         }
-
-        let child = pair
-            .slave
-            .spawn_command(cmd)
-            .context("Failed to spawn command")?;
-
-        Ok(Self {
-            master: pair.master,
-            child,
-            size,
-        })
     }
 
-    /// Get a reader for the PTY output.
+    #[cfg(unix)]
     pub fn reader(&self) -> Result<Box<dyn Read + Send>> {
         self.master
             .try_clone_reader()
             .context("Failed to clone PTY reader")
     }
 
-    /// Get a writer for the PTY input.
+    #[cfg(unix)]
     pub fn writer(&self) -> Result<Box<dyn Write + Send>> {
         self.master
             .take_writer()
             .context("Failed to take PTY writer")
     }
-    /// Get the current terminal size.
+
+    #[cfg(windows)]
+    fn take_reader(&mut self) -> Result<Box<dyn Read + Send>> {
+        self.reader
+            .take()
+            .context("Process reader already taken")
+    }
+
+    #[cfg(windows)]
+    fn take_writer(&mut self) -> Result<Box<dyn Write + Send>> {
+        self.writer
+            .take()
+            .context("Process writer already taken")
+    }
+
     pub fn size(&self) -> TermSize {
         self.size
     }
 
-    /// Consume the session and return the master PTY and child process.
-    ///
-    /// Used by AsyncPtyHandle to keep the master for resize operations
-    /// and the child for proper process cleanup on shutdown.
-    pub fn into_parts(self) -> (Box<dyn MasterPty + Send>, Box<dyn Child + Send + Sync>) {
-        (self.master, self.child)
+    #[cfg(unix)]
+    pub fn into_parts(self) -> (Box<dyn MasterPty + Send>, ManagedChild) {
+        (self.master, ManagedChild::Portable(self.child))
+    }
+
+    #[cfg(windows)]
+    fn into_child(self) -> ManagedChild {
+        ManagedChild::Std(self.child)
     }
 }
 
-/// Buffer size for reading from PTY.
+enum ManagedChild {
+    #[cfg(unix)]
+    Portable(Box<dyn Child + Send + Sync>),
+    #[cfg(windows)]
+    Std(std::process::Child),
+}
+
+impl ManagedChild {
+    fn kill(&mut self) -> Result<()> {
+        match self {
+            #[cfg(unix)]
+            Self::Portable(child) => child.kill().context("Failed to kill PTY child"),
+            #[cfg(windows)]
+            Self::Std(child) => child.kill().context("Failed to kill process child"),
+        }
+    }
+
+    fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>> {
+        match self {
+            #[cfg(unix)]
+            Self::Portable(child) => child.try_wait().context("Failed to poll PTY child"),
+            #[cfg(windows)]
+            Self::Std(child) => child.try_wait().context("Failed to poll process child"),
+        }
+    }
+}
+
+/// Buffer size for reading from PTY/process stdout.
 const READ_BUFFER_SIZE: usize = 4096;
 
-/// Handle for async PTY I/O operations.
-///
-/// Uses tokio channels for async I/O with background threads for the
-/// actual blocking PTY reads/writes.
+/// Handle for async terminal/process I/O operations.
 pub struct AsyncPtyHandle {
-    /// Sender for writing to PTY stdin.
     write_tx: mpsc::Sender<Vec<u8>>,
-    /// Receiver for reading from PTY stdout.
-    /// Wrapped in Mutex for interior mutability so read() can take &self,
-    /// avoiding the need for &mut self which would require exclusive session access.
     read_rx: tokio::sync::Mutex<mpsc::Receiver<Vec<u8>>>,
-    /// Flag to signal shutdown.
     shutdown: Arc<std::sync::atomic::AtomicBool>,
-    /// Master PTY for resize operations (sends SIGWINCH).
-    /// Wrapped in Mutex to make AsyncPtyHandle Sync.
+    #[cfg(unix)]
     master: std::sync::Mutex<Box<dyn MasterPty + Send>>,
-    /// Child process handle for cleanup on shutdown.
-    /// Wrapped in Mutex to allow killing from shutdown().
-    child: std::sync::Mutex<Box<dyn Child + Send + Sync>>,
-    /// Current terminal size, updated on resize.
-    /// Wrapped in Mutex for interior mutability.
+    child: std::sync::Mutex<ManagedChild>,
     size: std::sync::Mutex<TermSize>,
-    /// Handle to the reader thread for cleanup.
     reader_thread: Option<std::thread::JoinHandle<()>>,
-    /// Handle to the writer thread for cleanup.
     writer_thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl AsyncPtyHandle {
-    /// Create async I/O channels for a PTY session.
-    ///
-    /// This spawns background threads for reading and writing to the PTY.
+    /// Create async I/O channels for a PTY/process session.
     pub fn new(session: PtySession) -> Result<Self> {
-        let reader = session.reader()?;
-        let writer = session.writer()?;
-        let initial_size = session.size();
-        let (master, child) = session.into_parts();
+        #[cfg(unix)]
+        {
+            let reader = session.reader()?;
+            let writer = session.writer()?;
+            let initial_size = session.size();
+            let (master, child) = session.into_parts();
+            return Self::new_inner(reader, writer, initial_size, Some(master), child);
+        }
 
+        #[cfg(windows)]
+        {
+            let mut session = session;
+            let reader = session.take_reader()?;
+            let writer = session.take_writer()?;
+            let initial_size = session.size();
+            let child = session.into_child();
+            return Self::new_inner(reader, writer, initial_size, child);
+        }
+    }
+
+    #[cfg(unix)]
+    fn new_inner(
+        reader: Box<dyn Read + Send>,
+        writer: Box<dyn Write + Send>,
+        initial_size: TermSize,
+        master: Option<Box<dyn MasterPty + Send>>,
+        child: ManagedChild,
+    ) -> Result<Self> {
         let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
-
-        // Create channels
         let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(64);
         let (read_tx, read_rx) = mpsc::channel::<Vec<u8>>(64);
 
-        // Spawn reader thread
         let reader_shutdown = shutdown.clone();
         let reader_thread = std::thread::spawn(move || {
             Self::reader_loop(reader, read_tx, reader_shutdown);
         });
 
-        // Spawn writer thread
         let writer_thread = std::thread::spawn(move || {
             Self::writer_loop(writer, write_rx);
         });
@@ -163,7 +251,7 @@ impl AsyncPtyHandle {
             write_tx,
             read_rx: tokio::sync::Mutex::new(read_rx),
             shutdown,
-            master: std::sync::Mutex::new(master),
+            master: std::sync::Mutex::new(master.context("Missing PTY master")?),
             child: std::sync::Mutex::new(child),
             size: std::sync::Mutex::new(initial_size),
             reader_thread: Some(reader_thread),
@@ -171,41 +259,69 @@ impl AsyncPtyHandle {
         })
     }
 
-    /// Resize the PTY and send SIGWINCH to the child process.
-    ///
-    /// Also updates the internal size tracking. Use `size()` to query.
+    #[cfg(windows)]
+    fn new_inner(
+        reader: Box<dyn Read + Send>,
+        writer: Box<dyn Write + Send>,
+        initial_size: TermSize,
+        child: ManagedChild,
+    ) -> Result<Self> {
+        let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(64);
+        let (read_tx, read_rx) = mpsc::channel::<Vec<u8>>(64);
+
+        let reader_shutdown = shutdown.clone();
+        let reader_thread = std::thread::spawn(move || {
+            Self::reader_loop(reader, read_tx, reader_shutdown);
+        });
+
+        let writer_thread = std::thread::spawn(move || {
+            Self::writer_loop(writer, write_rx);
+        });
+
+        Ok(Self {
+            write_tx,
+            read_rx: tokio::sync::Mutex::new(read_rx),
+            shutdown,
+            child: std::sync::Mutex::new(child),
+            size: std::sync::Mutex::new(initial_size),
+            reader_thread: Some(reader_thread),
+            writer_thread: Some(writer_thread),
+        })
+    }
+
+    /// Resize the PTY. On Windows pipe-backed sessions this is currently a no-op.
     pub fn resize(&self, size: TermSize) -> Result<()> {
-        self.master
-            .lock()
-            .map_err(|_| anyhow::anyhow!("Master PTY mutex poisoned"))?
-            .resize(size.into())
-            .context("Failed to resize PTY")?;
-        // Update tracked size
+        #[cfg(unix)]
+        {
+            self.master
+                .lock()
+                .map_err(|_| anyhow::anyhow!("Master PTY mutex poisoned"))?
+                .resize(size.into())
+                .context("Failed to resize PTY")?;
+        }
+
         *self
             .size
             .lock()
             .map_err(|_| anyhow::anyhow!("Size mutex poisoned"))? = size;
         Ok(())
     }
-    /// Send bytes to the PTY stdin.
+
+    /// Send bytes to stdin.
     pub async fn write(&self, data: &[u8]) -> Result<()> {
         self.write_tx
             .send(data.to_vec())
             .await
-            .context("Failed to send to PTY input channel")
+            .context("Failed to send to input channel")
     }
 
-    /// Receive bytes from the PTY stdout.
-    ///
-    /// Returns None if the PTY has closed.
+    /// Receive bytes from stdout.
     pub async fn read(&self) -> Option<Vec<u8>> {
         self.read_rx.lock().await.recv().await
     }
 
-    /// Check if the child process has exited without blocking.
-    ///
-    /// Returns `Some(true)` if the process has exited, `Some(false)` if still running,
-    /// or `None` if the mutex is poisoned.
+    /// Check whether the child has exited.
     pub fn has_exited(&self) -> Option<bool> {
         self.child
             .lock()
@@ -214,22 +330,12 @@ impl AsyncPtyHandle {
             .map(|status| status.is_some())
     }
 
-    /// Shutdown the async PTY I/O and terminate the child process.
-    ///
-    /// This kills the child process to prevent orphaned processes,
-    /// then signals the I/O threads to stop.
+    /// Shutdown async I/O and terminate the child process.
     pub async fn shutdown(&self) {
-        // Kill the child process first to prevent orphaned processes
         if let Ok(mut child) = self.child.lock() {
             if let Err(e) = child.kill() {
-                // Log but don't fail - process may have already exited
-                debug!(
-                    "Failed to kill child process (may have already exited): {}",
-                    e
-                );
+                debug!("Failed to kill child process (may have already exited): {}", e);
             }
-            // Collect exit status to prevent zombie process accumulation.
-            // This is non-blocking since we just sent SIGKILL.
             if let Err(e) = child.try_wait() {
                 debug!("Failed to collect child exit status: {}", e);
             }
@@ -237,11 +343,9 @@ impl AsyncPtyHandle {
 
         self.shutdown
             .store(true, std::sync::atomic::Ordering::SeqCst);
-        // Close the channels to unblock threads
         self.read_rx.lock().await.close();
     }
 
-    /// Reader loop running in a background thread.
     fn reader_loop(
         mut reader: Box<dyn Read + Send>,
         read_tx: mpsc::Sender<Vec<u8>>,
@@ -261,7 +365,6 @@ impl AsyncPtyHandle {
                     break;
                 }
                 Ok(n) => {
-                    // Use blocking send since we're in a thread
                     if read_tx.blocking_send(buf[..n].to_vec()).is_err() {
                         debug!("PTY read channel closed");
                         break;
@@ -278,9 +381,7 @@ impl AsyncPtyHandle {
         }
     }
 
-    /// Writer loop running in a background thread.
     fn writer_loop(mut writer: Box<dyn Write + Send>, mut write_rx: mpsc::Receiver<Vec<u8>>) {
-        // Use blocking_recv since we're in a thread
         while let Some(data) = write_rx.blocking_recv() {
             if let Err(e) = writer.write_all(&data) {
                 error!("PTY write error: {}", e);
@@ -297,54 +398,32 @@ impl AsyncPtyHandle {
 
 impl Drop for AsyncPtyHandle {
     fn drop(&mut self) {
-        // Kill the child process first to prevent orphaned processes.
-        // This mirrors the logic in shutdown() but is synchronous since Drop can't be async.
         if let Ok(mut child) = self.child.lock() {
             if let Err(e) = child.kill() {
-                // Process may have already exited, that's fine
-                debug!(
-                    "Failed to kill child on drop (may have already exited): {}",
-                    e
-                );
+                debug!("Failed to kill child on drop (may have already exited): {}", e);
             }
-            // Collect exit status to prevent zombie accumulation
             if let Err(e) = child.try_wait() {
                 debug!("Failed to collect child exit status on drop: {}", e);
             }
         }
 
-        // Signal threads to shutdown
         self.shutdown
             .store(true, std::sync::atomic::Ordering::SeqCst);
 
-        // Note: We intentionally don't block on join() here because:
-        // 1. The reader thread may be blocked on a synchronous read() call
-        //    which cannot be interrupted without closing the PTY fd
-        // 2. The threads will terminate on their own when:
-        //    - Reader: PTY closes (EOF) or channel is dropped
-        //    - Writer: Channel closes when write_tx is dropped
-        //
-        // The thread handles are stored so they're not detached (which would
-        // cause issues with thread-local storage), but we don't wait for them.
-        // This is acceptable because the threads don't hold any resources that
-        // need explicit cleanup - the channels and PTY handles are cleaned up
-        // by their own Drop implementations.
-
-        // Log if threads are still running (helpful for debugging)
         if let Some(ref handle) = self.reader_thread {
             if !handle.is_finished() {
-                debug!("PTY reader thread still running on drop, will terminate on PTY close");
+                debug!("PTY reader thread still running on drop, will terminate on close");
             }
         }
         if let Some(ref handle) = self.writer_thread {
             if !handle.is_finished() {
-                debug!("PTY writer thread still running on drop, will terminate on channel close");
+                debug!("PTY writer thread still running on drop, will terminate on close");
             }
         }
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(windows)))]
 mod tests {
     use super::*;
     use std::io::Read;
@@ -361,14 +440,10 @@ mod tests {
 
         let mut reader = session.reader().expect("Failed to get reader");
 
-        // Read output with timeout
         let mut output = vec![0u8; 1024];
         let mut total_read = 0;
-
-        // Give the process time to write output
         std::thread::sleep(Duration::from_millis(100));
 
-        // Read available data
         loop {
             match reader.read(&mut output[total_read..]) {
                 Ok(0) => break,
@@ -377,7 +452,6 @@ mod tests {
                     if total_read >= output.len() {
                         break;
                     }
-                    // Check if we got our expected output
                     let s = String::from_utf8_lossy(&output[..total_read]);
                     if s.contains("hello") {
                         break;
@@ -400,21 +474,16 @@ mod tests {
 
     #[test]
     fn test_spawn_and_write_input() {
-        // Spawn cat which echoes input
         let session = PtySession::spawn(&["cat".to_string()], TermSize::default(), None)
             .expect("Failed to spawn cat");
 
         let mut writer = session.writer().expect("Failed to get writer");
         let mut reader = session.reader().expect("Failed to get reader");
 
-        // Write some input
         writer.write_all(b"test input\n").expect("Failed to write");
         writer.flush().expect("Failed to flush");
-
-        // Give it time to echo back
         std::thread::sleep(Duration::from_millis(100));
 
-        // Read the echoed output
         let mut output = vec![0u8; 256];
         let mut total_read = 0;
 
@@ -445,41 +514,25 @@ mod tests {
 
     #[tokio::test]
     async fn test_async_pty_bash_exit() {
-        // Spawn bash
         let session = PtySession::spawn(&["bash".to_string()], TermSize::default(), None)
             .expect("Failed to spawn bash");
 
         let handle = AsyncPtyHandle::new(session).expect("Failed to create async handle");
 
-        // Give bash time to start and print prompt
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        // Drain any initial output (prompt, etc.)
         while let Ok(Some(_)) =
             tokio::time::timeout(Duration::from_millis(100), handle.read()).await
-        {
-            // Keep reading until no more output
-        }
+        {}
 
-        // Send exit command
         handle.write(b"exit\n").await.expect("Failed to write exit");
-
-        // Wait a bit for bash to process
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        // The channel should close when bash exits
-        // Try to read, should eventually return None or timeout
         let _ = tokio::time::timeout(Duration::from_secs(2), async {
-            while handle.read().await.is_some() {
-                // Keep reading until EOF
-            }
+            while handle.read().await.is_some() {}
         })
         .await;
 
-        // Either channel closed or we timed out - both are acceptable
-        // since we sent exit and bash should have terminated
-
-        // Shutdown should complete without hanging
         let shutdown_result = tokio::time::timeout(Duration::from_secs(2), handle.shutdown()).await;
         assert!(
             shutdown_result.is_ok(),
@@ -489,13 +542,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_async_pty_handle_resize() {
-        // Spawn a shell
         let session = PtySession::spawn(&["sh".to_string()], TermSize { cols: 80, rows: 24 }, None)
             .expect("spawn");
 
         let handle = AsyncPtyHandle::new(session).expect("async handle");
 
-        // Resize via AsyncPtyHandle (sends SIGWINCH to child process)
         handle
             .resize(TermSize {
                 cols: 120,
@@ -503,7 +554,6 @@ mod tests {
             })
             .expect("resize via async handle should succeed");
 
-        // Resize to smaller
         handle
             .resize(TermSize { cols: 40, rows: 10 })
             .expect("resize to smaller should succeed");
@@ -511,14 +561,10 @@ mod tests {
 
     #[test]
     fn test_spawn_with_cwd() {
-        // Spawn pwd in /tmp and verify it outputs a path containing "tmp"
-        // Note: On macOS, /tmp is a symlink to /private/tmp
         let session = PtySession::spawn(&["pwd".to_string()], TermSize::default(), Some("/tmp"))
             .expect("Failed to spawn pwd with cwd");
 
         let mut reader = session.reader().expect("Failed to get reader");
-
-        // Give the process time to write output
         std::thread::sleep(Duration::from_millis(100));
 
         let mut output = vec![0u8; 256];
@@ -530,7 +576,6 @@ mod tests {
                 Ok(n) => {
                     total_read += n;
                     let s = String::from_utf8_lossy(&output[..total_read]);
-                    // Check for tmp (handles both /tmp and /private/tmp on macOS)
                     if s.contains("tmp") {
                         break;
                     }

--- a/crates/pilotty-cli/src/daemon/server.rs
+++ b/crates/pilotty-cli/src/daemon/server.rs
@@ -1,4 +1,4 @@
-//! Unix socket server for the daemon process.
+//! Cross-platform daemon server transport.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -10,11 +10,11 @@ use pilotty_core::input::encode_mouse_click_combined;
 use pilotty_core::protocol::{Command, Request, Response, ResponseData, SnapshotFormat};
 use pilotty_core::snapshot::{CursorState, ScreenState, TerminalSize};
 use tokio::io::{AsyncWriteExt, BufReader};
-use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{Notify, Semaphore};
 use tokio::task::JoinSet;
 use tracing::{debug, error, info, warn};
 
+use crate::daemon::transport;
 use crate::daemon::paths;
 use crate::daemon::session::{SessionId, SessionManager};
 
@@ -32,7 +32,7 @@ const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The daemon server that listens for client connections.
 pub struct DaemonServer {
-    listener: UnixListener,
+    listener: transport::Listener,
     socket_path: PathBuf,
     pid_path: PathBuf,
     sessions: Arc<SessionManager>,
@@ -76,36 +76,35 @@ impl DaemonServer {
         };
 
         // Try to bind directly (avoid TOCTOU race)
-        let listener = match UnixListener::bind(&socket_path) {
+        let listener = match transport::bind(&socket_path).await {
             Ok(l) => {
                 // Write PID immediately after bind to prevent race condition
                 write_pid(&pid_path)?;
                 l
             }
-            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            Err(e) if transport::is_addr_in_use(&e) => {
                 // Socket exists, check if daemon is still alive
                 if is_daemon_alive(&pid_path) {
                     anyhow::bail!(
-                        "Daemon already running (socket {:?} in use, PID file valid)",
-                        socket_path
+                        "Daemon already running (endpoint {} in use, PID file valid)",
+                        transport::describe_endpoint(&socket_path)
                     );
                 }
 
-                // Daemon is dead, but verify the socket file is safe to remove
-                // Don't follow symlinks (could delete unintended files)
-                let metadata = std::fs::symlink_metadata(&socket_path)
-                    .with_context(|| format!("Failed to stat socket path: {:?}", socket_path))?;
-
-                if metadata.file_type().is_symlink() {
-                    anyhow::bail!(
-                        "Socket path {:?} is a symlink, refusing to delete for safety",
-                        socket_path
-                    );
-                }
-
-                // On Unix, verify it's actually a socket file
                 #[cfg(unix)]
                 {
+                    // Daemon is dead, but verify the socket file is safe to remove.
+                    // Don't follow symlinks (could delete unintended files).
+                    let metadata = std::fs::symlink_metadata(&socket_path)
+                        .with_context(|| format!("Failed to stat socket path: {:?}", socket_path))?;
+
+                    if metadata.file_type().is_symlink() {
+                        anyhow::bail!(
+                            "Socket path {:?} is a symlink, refusing to delete for safety",
+                            socket_path
+                        );
+                    }
+
                     use std::os::unix::fs::FileTypeExt;
                     if !metadata.file_type().is_socket() {
                         anyhow::bail!(
@@ -114,18 +113,27 @@ impl DaemonServer {
                             metadata.file_type()
                         );
                     }
+
+                    info!("Removing stale socket from dead daemon");
+                    std::fs::remove_file(&socket_path).with_context(|| {
+                        format!("Failed to remove stale socket: {:?}", socket_path)
+                    })?;
+
+                    let l = transport::bind(&socket_path)
+                        .await
+                        .with_context(|| format!("Failed to bind to socket: {:?}", socket_path))?;
+                    write_pid(&pid_path)?;
+                    l
                 }
 
-                // Safe to remove stale socket
-                info!("Removing stale socket from dead daemon");
-                std::fs::remove_file(&socket_path)
-                    .with_context(|| format!("Failed to remove stale socket: {:?}", socket_path))?;
-
-                let l = UnixListener::bind(&socket_path)
-                    .with_context(|| format!("Failed to bind to socket: {:?}", socket_path))?;
-                // Write PID immediately after bind to prevent race condition
-                write_pid(&pid_path)?;
-                l
+                #[cfg(windows)]
+                {
+                    anyhow::bail!(
+                        "Daemon endpoint {} is already in use, but the PID file {:?} does not point to a live daemon. Another process may be occupying the TCP port.",
+                        transport::describe_endpoint(&socket_path),
+                        pid_path
+                    );
+                }
             }
             Err(e) => {
                 return Err(e)
@@ -133,7 +141,10 @@ impl DaemonServer {
             }
         };
 
-        info!("Daemon listening on {:?}", socket_path);
+        transport::write_endpoint_marker(&socket_path)
+            .with_context(|| format!("Failed to write endpoint marker: {:?}", socket_path))?;
+
+        info!("Daemon listening on {}", transport::describe_endpoint(&socket_path));
 
         Ok(Self {
             listener,
@@ -368,7 +379,35 @@ fn is_daemon_alive(pid_path: &Path) -> bool {
     // SAFETY: libc::kill with signal 0 is a POSIX-defined no-op that only checks
     // whether the process exists and the caller has permission to signal it.
     // The pid is validated as a valid i32 above. No actual signal is delivered.
-    unsafe { libc::kill(pid, 0) == 0 }
+    #[cfg(unix)]
+    {
+        // kill(pid, 0) checks if process exists without sending a signal.
+        // SAFETY: libc::kill with signal 0 is a POSIX-defined no-op that only checks
+        // whether the process exists and the caller has permission to signal it.
+        // The pid is validated as a valid i32 above. No actual signal is delivered.
+        return unsafe { libc::kill(pid, 0) == 0 };
+    }
+
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        const STILL_ACTIVE: u32 = 259;
+
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid as u32) };
+
+        if handle == std::ptr::null_mut() {
+            return false;
+        }
+
+        let mut exit_code = 0u32;
+        let running = unsafe { GetExitCodeProcess(handle, &mut exit_code) != 0 && exit_code == STILL_ACTIVE };
+        unsafe { CloseHandle(handle) };
+        running
+    }
 }
 
 /// Maximum request size in bytes (1 MB should be plenty for any reasonable request).
@@ -441,7 +480,7 @@ async fn read_line_bounded<R: tokio::io::AsyncBufRead + Unpin>(
 
 /// Handle a single client connection.
 async fn handle_connection(
-    stream: UnixStream,
+    stream: transport::Stream,
     sessions: Arc<SessionManager>,
     shutdown: Arc<Notify>,
 ) -> Result<()> {
@@ -1304,7 +1343,7 @@ async fn handle_shutdown(
     )
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(windows)))]
 mod tests {
     use super::*;
     use pilotty_core::error::ErrorCode;

--- a/crates/pilotty-cli/src/daemon/server.rs
+++ b/crates/pilotty-cli/src/daemon/server.rs
@@ -128,11 +128,17 @@ impl DaemonServer {
 
                 #[cfg(windows)]
                 {
-                    anyhow::bail!(
-                        "Daemon endpoint {} is already in use, but the PID file {:?} does not point to a live daemon. Another process may be occupying the TCP port.",
+                    info!(
+                        "Preferred daemon endpoint {} is occupied and PID file {:?} is stale; falling back to another loopback port",
                         transport::describe_endpoint(&socket_path),
                         pid_path
                     );
+
+                    let l = transport::bind_fallback(&socket_path)
+                        .await
+                        .with_context(|| format!("Failed to bind fallback endpoint for {:?}", socket_path))?;
+                    write_pid(&pid_path)?;
+                    l
                 }
             }
             Err(e) => {
@@ -141,10 +147,10 @@ impl DaemonServer {
             }
         };
 
-        transport::write_endpoint_marker(&socket_path)
+        transport::write_endpoint_marker(&socket_path, &listener)
             .with_context(|| format!("Failed to write endpoint marker: {:?}", socket_path))?;
 
-        info!("Daemon listening on {}", transport::describe_endpoint(&socket_path));
+        info!("Daemon listening on {}", transport::describe_listener(&listener));
 
         Ok(Self {
             listener,

--- a/crates/pilotty-cli/src/daemon/session.rs
+++ b/crates/pilotty-cli/src/daemon/session.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use tokio::sync::{Mutex, RwLock};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use pilotty_core::elements::classify::{detect, ClassifyContext};
 use pilotty_core::elements::Element;
@@ -79,7 +79,7 @@ pub struct Session {
     /// Terminal size.
     pub size: TermSize,
     /// Async handle for PTY I/O.
-    pub pty: AsyncPtyHandle,
+    pub pty: Arc<AsyncPtyHandle>,
     /// Terminal emulator tracking screen state.
     /// Wrapped in Mutex for interior mutability (fed by PTY reader task).
     pub terminal: Arc<Mutex<TerminalEmulator>>,
@@ -106,71 +106,81 @@ impl Session {
         self.pty.write(data).await
     }
 
-    /// Drain pending PTY output and feed to terminal emulator.
-    ///
-    /// Call this before taking a snapshot to ensure screen state is current.
-    ///
-    /// To prevent blocking on noisy processes, this has limits:
-    /// - Maximum 100 iterations (reads)
-    /// - Maximum 1MB total data
-    /// - 10ms timeout per read
-    ///
-    /// These limits ensure the drain completes quickly even with high-output processes.
-    pub async fn drain_pty_output(&self) {
-        use std::time::Duration;
-        use tokio::time::timeout;
-
-        // Limits to prevent blocking on noisy processes
-        const MAX_ITERATIONS: usize = 100;
-        const MAX_BYTES: usize = 1024 * 1024; // 1 MB
-
-        let mut terminal = self.terminal.lock().await;
-        let mut iterations = 0;
-        let mut total_bytes = 0;
-
-        // Read available data from PTY (non-blocking via short timeout)
-        loop {
-            if iterations >= MAX_ITERATIONS {
-                debug!(
-                    "Drain hit iteration limit ({} iterations, {} bytes)",
-                    iterations, total_bytes
-                );
-                break;
-            }
-
-            match timeout(Duration::from_millis(10), self.pty.read()).await {
-                Ok(Some(data)) => {
-                    let len = data.len();
-                    debug!("Fed {} bytes to terminal emulator", len);
-                    terminal.feed(&data);
-
-                    iterations += 1;
-                    total_bytes += len;
-
-                    if total_bytes >= MAX_BYTES {
-                        debug!(
-                            "Drain hit byte limit ({} iterations, {} bytes)",
-                            iterations, total_bytes
-                        );
-                        break;
-                    }
-                }
-                Ok(None) => {
-                    // PTY closed
-                    debug!("PTY channel closed");
-                    break;
-                }
-                Err(_) => {
-                    // Timeout - no more data available
-                    break;
-                }
-            }
-        }
-    }
 }
 
 /// Maximum number of concurrent sessions to prevent resource exhaustion.
 const MAX_SESSIONS: usize = 100;
+
+fn spawn_output_pump(
+    session_id: SessionId,
+    pty: Arc<AsyncPtyHandle>,
+    terminal: Arc<Mutex<TerminalEmulator>>,
+) {
+    tokio::spawn(async move {
+        while let Some(data) = pty.read().await {
+            debug!(
+                "PTY output pump read {} bytes from session {}",
+                data.len(), session_id
+            );
+            let responses = {
+                let mut terminal = terminal.lock().await;
+                feed_terminal_and_collect_responses(&mut terminal, &data)
+            };
+
+            for response in responses {
+                if let Err(e) = pty.write(&response).await {
+                    warn!(
+                        "Failed to send terminal response back to session {}: {}",
+                        session_id, e
+                    );
+                    return;
+                }
+            }
+        }
+
+        debug!("PTY output pump ended for session {}", session_id);
+    });
+}
+
+fn feed_terminal_and_collect_responses(
+    terminal: &mut TerminalEmulator,
+    data: &[u8],
+) -> Vec<Vec<u8>> {
+    let mut responses = Vec::new();
+    let mut segment_start = 0usize;
+    let mut i = 0usize;
+
+    while i < data.len() {
+        let response = if data[i..].starts_with(b"\x1b[6n") {
+            let (row, col) = terminal.cursor_position();
+            Some((4usize, format!("\x1b[{};{}R", row + 1, col + 1).into_bytes()))
+        } else if data[i..].starts_with(b"\x1b[?6n") {
+            let (row, col) = terminal.cursor_position();
+            Some((5usize, format!("\x1b[?{};{}R", row + 1, col + 1).into_bytes()))
+        } else {
+            None
+        };
+
+        if let Some((query_len, response)) = response {
+            if segment_start < i {
+                terminal.feed(&data[segment_start..i]);
+            }
+            debug!("Responding to terminal query with {:?}", String::from_utf8_lossy(&response));
+            responses.push(response);
+            i += query_len;
+            segment_start = i;
+            continue;
+        }
+
+        i += 1;
+    }
+
+    if segment_start < data.len() {
+        terminal.feed(&data[segment_start..]);
+    }
+
+    responses
+}
 
 /// Manages active PTY sessions.
 ///
@@ -242,13 +252,17 @@ impl SessionManager {
             .map_err(|e| ApiError::spawn_failed(&command, &e.to_string()))?;
 
         // Wrap in async handle
-        let pty = AsyncPtyHandle::new(pty_session)
-            .map_err(|e| ApiError::spawn_failed(&command, &e.to_string()))?;
+        let pty = Arc::new(
+            AsyncPtyHandle::new(pty_session)
+                .map_err(|e| ApiError::spawn_failed(&command, &e.to_string()))?,
+        );
 
         // Create terminal emulator to track screen state
         let terminal = Arc::new(Mutex::new(TerminalEmulator::new(size)));
 
         let id = SessionId::new();
+        spawn_output_pump(id.clone(), pty.clone(), terminal.clone());
+
         let session = Session {
             id: id.clone(),
             name,
@@ -388,9 +402,7 @@ impl SessionManager {
             .get(id)
             .ok_or_else(|| ApiError::session_not_found(&id.0))?;
 
-        // Drain pending PTY output to update terminal state
-        session.drain_pty_output().await;
-
+        // Output is pumped into the terminal emulator continuously.
         // Lock terminal once for all reads
         let terminal = session.terminal.lock().await;
 
@@ -484,8 +496,6 @@ impl SessionManager {
             .get(id)
             .ok_or_else(|| ApiError::session_not_found(&id.0))?;
 
-        // Drain to get current terminal state
-        session.drain_pty_output().await;
         Ok(session.application_cursor().await)
     }
 

--- a/crates/pilotty-cli/src/daemon/session.rs
+++ b/crates/pilotty-cli/src/daemon/session.rs
@@ -545,7 +545,7 @@ impl SessionManager {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(windows)))]
 mod tests {
     use super::*;
 

--- a/crates/pilotty-cli/src/daemon/transport.rs
+++ b/crates/pilotty-cli/src/daemon/transport.rs
@@ -1,7 +1,8 @@
 //! Cross-platform transport for daemon/client communication.
 //!
 //! Unix uses Unix domain sockets.
-//! Windows uses a loopback TCP listener derived from the socket path.
+//! Windows uses a loopback TCP listener, with the endpoint marker file storing
+//! the actual bound port so we can recover from collisions on the preferred one.
 
 use std::io;
 use std::path::Path;
@@ -17,6 +18,10 @@ pub type Listener = tokio::net::TcpListener;
 pub type Stream = tokio::net::TcpStream;
 
 /// Bind a daemon listener for the given endpoint path.
+///
+/// On Windows this binds the preferred deterministic port derived from the
+/// endpoint path. If that port is occupied, callers may use `bind_fallback()`
+/// after deciding it is safe to do so.
 pub async fn bind(endpoint: &Path) -> io::Result<Listener> {
     #[cfg(unix)]
     {
@@ -25,8 +30,36 @@ pub async fn bind(endpoint: &Path) -> io::Result<Listener> {
 
     #[cfg(windows)]
     {
-        tokio::net::TcpListener::bind(socket_addr(endpoint)).await
+        tokio::net::TcpListener::bind(preferred_socket_addr(endpoint)).await
     }
+}
+
+/// Bind a fallback daemon listener if the preferred endpoint is unavailable.
+#[cfg(unix)]
+pub async fn bind_fallback(endpoint: &Path) -> io::Result<Listener> {
+    bind(endpoint).await
+}
+
+/// Bind a fallback daemon listener if the preferred port is unavailable.
+#[cfg(windows)]
+pub async fn bind_fallback(endpoint: &Path) -> io::Result<Listener> {
+    let preferred = preferred_socket_addr(endpoint);
+    let start_port = preferred.port();
+
+    for offset in 1..=u32::from(PORT_SPAN) {
+        let next_port = BASE_PORT + (((start_port - BASE_PORT) as u32 + offset) % u32::from(PORT_SPAN)) as u16;
+        let addr = std::net::SocketAddr::new(preferred.ip(), next_port);
+        match tokio::net::TcpListener::bind(addr).await {
+            Ok(listener) => return Ok(listener),
+            Err(err) if err.kind() == io::ErrorKind::AddrInUse => continue,
+            Err(err) => return Err(err),
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::AddrInUse,
+        "No free loopback TCP port available for pilotty daemon",
+    ))
 }
 
 /// Connect to a daemon endpoint.
@@ -38,7 +71,13 @@ pub async fn connect(endpoint: &Path) -> io::Result<Stream> {
 
     #[cfg(windows)]
     {
-        tokio::net::TcpStream::connect(socket_addr(endpoint)).await
+        if let Some(addr) = read_endpoint_marker(endpoint) {
+            if let Ok(stream) = tokio::net::TcpStream::connect(addr).await {
+                return Ok(stream);
+            }
+        }
+
+        tokio::net::TcpStream::connect(preferred_socket_addr(endpoint)).await
     }
 }
 
@@ -50,18 +89,20 @@ pub fn is_addr_in_use(err: &io::Error) -> bool {
 /// Write a small marker file describing the endpoint.
 ///
 /// On Unix the socket itself is the endpoint, so this is a no-op.
-/// On Windows we keep a marker file so the existing path-based cleanup logic
-/// still has something tangible to remove and inspect.
-pub fn write_endpoint_marker(endpoint: &Path) -> io::Result<()> {
+/// On Windows we keep a marker file containing the bound loopback address so
+/// clients can reconnect even if the daemon had to fall back from the preferred
+/// deterministic port.
+pub fn write_endpoint_marker(endpoint: &Path, listener: &Listener) -> io::Result<()> {
     #[cfg(unix)]
     {
         let _ = endpoint;
+        let _ = listener;
         Ok(())
     }
 
     #[cfg(windows)]
     {
-        std::fs::write(endpoint, socket_addr(endpoint).to_string())
+        std::fs::write(endpoint, listener.local_addr()?.to_string())
     }
 }
 
@@ -74,22 +115,46 @@ pub fn describe_endpoint(endpoint: &Path) -> String {
 
     #[cfg(windows)]
     {
-        socket_addr(endpoint).to_string()
+        preferred_socket_addr(endpoint).to_string()
     }
 }
 
+/// Return the actual listener address.
+#[cfg(unix)]
+pub fn describe_listener(_listener: &Listener) -> String {
+    "unix-listener".to_string()
+}
+
+/// Return the actual listener address.
 #[cfg(windows)]
-fn socket_addr(endpoint: &Path) -> std::net::SocketAddr {
+pub fn describe_listener(listener: &Listener) -> String {
+    listener
+        .local_addr()
+        .map(|addr| addr.to_string())
+        .unwrap_or_else(|_| "127.0.0.1:<unknown>".to_string())
+}
+
+#[cfg(windows)]
+const BASE_PORT: u16 = 43000;
+#[cfg(windows)]
+const PORT_SPAN: u16 = 20_000;
+
+#[cfg(windows)]
+fn preferred_socket_addr(endpoint: &Path) -> std::net::SocketAddr {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-    const BASE_PORT: u16 = 43000;
-    const PORT_SPAN: u16 = 20_000;
 
     let mut hasher = DefaultHasher::new();
     endpoint.to_string_lossy().hash(&mut hasher);
     let offset = (hasher.finish() % u64::from(PORT_SPAN)) as u16;
 
     SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), BASE_PORT + offset)
+}
+
+#[cfg(windows)]
+fn read_endpoint_marker(endpoint: &Path) -> Option<std::net::SocketAddr> {
+    std::fs::read_to_string(endpoint)
+        .ok()
+        .and_then(|text| text.trim().parse().ok())
 }

--- a/crates/pilotty-cli/src/daemon/transport.rs
+++ b/crates/pilotty-cli/src/daemon/transport.rs
@@ -1,0 +1,95 @@
+//! Cross-platform transport for daemon/client communication.
+//!
+//! Unix uses Unix domain sockets.
+//! Windows uses a loopback TCP listener derived from the socket path.
+
+use std::io;
+use std::path::Path;
+
+#[cfg(unix)]
+pub type Listener = tokio::net::UnixListener;
+#[cfg(unix)]
+pub type Stream = tokio::net::UnixStream;
+
+#[cfg(windows)]
+pub type Listener = tokio::net::TcpListener;
+#[cfg(windows)]
+pub type Stream = tokio::net::TcpStream;
+
+/// Bind a daemon listener for the given endpoint path.
+pub async fn bind(endpoint: &Path) -> io::Result<Listener> {
+    #[cfg(unix)]
+    {
+        tokio::net::UnixListener::bind(endpoint)
+    }
+
+    #[cfg(windows)]
+    {
+        tokio::net::TcpListener::bind(socket_addr(endpoint)).await
+    }
+}
+
+/// Connect to a daemon endpoint.
+pub async fn connect(endpoint: &Path) -> io::Result<Stream> {
+    #[cfg(unix)]
+    {
+        tokio::net::UnixStream::connect(endpoint).await
+    }
+
+    #[cfg(windows)]
+    {
+        tokio::net::TcpStream::connect(socket_addr(endpoint)).await
+    }
+}
+
+/// Whether an I/O error indicates the endpoint is already in use.
+pub fn is_addr_in_use(err: &io::Error) -> bool {
+    err.kind() == io::ErrorKind::AddrInUse
+}
+
+/// Write a small marker file describing the endpoint.
+///
+/// On Unix the socket itself is the endpoint, so this is a no-op.
+/// On Windows we keep a marker file so the existing path-based cleanup logic
+/// still has something tangible to remove and inspect.
+pub fn write_endpoint_marker(endpoint: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let _ = endpoint;
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    {
+        std::fs::write(endpoint, socket_addr(endpoint).to_string())
+    }
+}
+
+/// Return a human-readable endpoint description.
+pub fn describe_endpoint(endpoint: &Path) -> String {
+    #[cfg(unix)]
+    {
+        endpoint.display().to_string()
+    }
+
+    #[cfg(windows)]
+    {
+        socket_addr(endpoint).to_string()
+    }
+}
+
+#[cfg(windows)]
+fn socket_addr(endpoint: &Path) -> std::net::SocketAddr {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    const BASE_PORT: u16 = 43000;
+    const PORT_SPAN: u16 = 20_000;
+
+    let mut hasher = DefaultHasher::new();
+    endpoint.to_string_lossy().hash(&mut hasher);
+    let offset = (hasher.finish() % u64::from(PORT_SPAN)) as u16;
+
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), BASE_PORT + offset)
+}

--- a/crates/pilotty-cli/src/main.rs
+++ b/crates/pilotty-cli/src/main.rs
@@ -3,6 +3,9 @@
 mod args;
 mod daemon;
 
+use std::path::Path;
+
+use anyhow::bail;
 use clap::Parser;
 use pilotty_core::protocol::{Command, Request, ResponseData, ScrollDirection, SnapshotFormat};
 use tracing::{error, info};
@@ -39,22 +42,34 @@ fn main() {
 /// Convert CLI args to a protocol Command.
 ///
 /// Returns None for commands that don't require daemon communication.
-fn cli_to_command(cli: &Cli) -> Option<Command> {
+fn cli_to_command(cli: &Cli) -> anyhow::Result<Option<Command>> {
     match &cli.command {
-        Commands::Spawn(args) => Some(Command::Spawn {
-            command: args.command.clone(),
-            session_name: args.name.clone(),
-            // Default to client's cwd if --cwd not explicitly provided
-            cwd: args.cwd.clone().or_else(|| {
-                std::env::current_dir()
-                    .ok()
-                    .map(|p| p.to_string_lossy().into_owned())
-            }),
-        }),
-        Commands::Kill(args) => Some(Command::Kill {
+        Commands::Spawn(args) => {
+            if args.shell_program.is_some() && !args.shell {
+                bail!("--shell-program requires --shell");
+            }
+
+            let command = if args.shell {
+                build_shell_command(&args.command, args.shell_program.as_deref())?
+            } else {
+                args.command.clone()
+            };
+
+            Ok(Some(Command::Spawn {
+                command,
+                session_name: args.name.clone(),
+                // Default to client's cwd if --cwd not explicitly provided
+                cwd: args.cwd.clone().or_else(|| {
+                    std::env::current_dir()
+                        .ok()
+                        .map(|p| p.to_string_lossy().into_owned())
+                }),
+            }))
+        }
+        Commands::Kill(args) => Ok(Some(Command::Kill {
             session: args.session.clone(),
-        }),
-        Commands::Snapshot(args) => Some(Command::Snapshot {
+        })),
+        Commands::Snapshot(args) => Ok(Some(Command::Snapshot {
             session: args.session.clone(),
             format: Some(match args.format {
                 crate::args::SnapshotFormat::Full => SnapshotFormat::Full,
@@ -64,51 +79,172 @@ fn cli_to_command(cli: &Cli) -> Option<Command> {
             await_change: args.await_change,
             settle_ms: args.settle,
             timeout_ms: args.timeout,
-        }),
-        Commands::Type(args) => Some(Command::Type {
+        })),
+        Commands::Type(args) => Ok(Some(Command::Type {
             text: args.text.clone(),
             session: args.session.clone(),
-        }),
-        Commands::Key(args) => Some(Command::Key {
+        })),
+        Commands::Key(args) => Ok(Some(Command::Key {
             key: args.key.clone(),
             delay_ms: args.delay,
             session: args.session.clone(),
-        }),
-        Commands::Click(args) => Some(Command::Click {
+        })),
+        Commands::Click(args) => Ok(Some(Command::Click {
             row: args.row,
             col: args.col,
             session: args.session.clone(),
-        }),
-        Commands::Scroll(args) => Some(Command::Scroll {
+        })),
+        Commands::Scroll(args) => Ok(Some(Command::Scroll {
             direction: match args.direction {
                 crate::args::ScrollDirection::Up => ScrollDirection::Up,
                 crate::args::ScrollDirection::Down => ScrollDirection::Down,
             },
             amount: args.amount,
             session: args.session.clone(),
-        }),
-        Commands::ListSessions => Some(Command::ListSessions),
-        Commands::Resize(args) => Some(Command::Resize {
+        })),
+        Commands::ListSessions => Ok(Some(Command::ListSessions)),
+        Commands::Resize(args) => Ok(Some(Command::Resize {
             cols: args.cols,
             rows: args.rows,
             session: args.session.clone(),
-        }),
-        Commands::WaitFor(args) => Some(Command::WaitFor {
+        })),
+        Commands::WaitFor(args) => Ok(Some(Command::WaitFor {
             pattern: args.pattern.clone(),
             timeout_ms: Some(args.timeout),
             regex: Some(args.regex),
             session: args.session.clone(),
-        }),
+        })),
         Commands::Daemon => unreachable!("Daemon command handled separately"),
-        Commands::Examples => None,
-        Commands::Stop => Some(Command::Shutdown),
+        Commands::Examples => Ok(None),
+        Commands::Stop => Ok(Some(Command::Shutdown)),
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShellKind {
+    Posix,
+    PowerShell,
+    Cmd,
+}
+
+fn build_shell_command(command: &[String], shell_program_override: Option<&str>) -> anyhow::Result<Vec<String>> {
+    if command.is_empty() {
+        bail!("Shell command cannot be empty");
+    }
+
+    let shell_program = resolve_shell_program(shell_program_override)?;
+    let shell_kind = classify_shell(&shell_program);
+    let shell_command = match shell_kind {
+        ShellKind::Posix => quote_posix_command(command),
+        ShellKind::PowerShell => quote_powershell_command(command),
+        ShellKind::Cmd => quote_cmd_command(command),
+    };
+
+    let args = match shell_kind {
+        ShellKind::Posix => vec!["-lc".to_string(), shell_command],
+        ShellKind::PowerShell => vec!["-NoLogo".to_string(), "-Command".to_string(), shell_command],
+        ShellKind::Cmd => vec!["/d".to_string(), "/s".to_string(), "/c".to_string(), shell_command],
+    };
+
+    let mut result = Vec::with_capacity(1 + args.len());
+    result.push(shell_program);
+    result.extend(args);
+    Ok(result)
+}
+
+fn resolve_shell_program(shell_program_override: Option<&str>) -> anyhow::Result<String> {
+    if let Some(program) = shell_program_override.filter(|s| !s.trim().is_empty()) {
+        return Ok(program.to_string());
+    }
+
+    for candidate in [
+        std::env::var("PILOTTY_SHELL").ok(),
+        std::env::var("SHELL").ok(),
+        #[cfg(windows)]
+        std::env::var("COMSPEC").ok(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if !candidate.trim().is_empty() {
+            return Ok(candidate);
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        let git_bash = "C:/Program Files/Git/bin/bash.exe";
+        if Path::new(git_bash).exists() {
+            return Ok(git_bash.to_string());
+        }
+        return Ok("powershell.exe".to_string());
+    }
+
+    #[cfg(not(windows))]
+    {
+        Ok("/bin/sh".to_string())
+    }
+}
+
+fn classify_shell(program: &str) -> ShellKind {
+    let lower = program.replace('\\', "/").to_ascii_lowercase();
+    if lower.ends_with("cmd") || lower.ends_with("cmd.exe") || lower == "cmd" {
+        ShellKind::Cmd
+    } else if lower.contains("powershell") || lower.ends_with("pwsh") || lower.ends_with("pwsh.exe") {
+        ShellKind::PowerShell
+    } else {
+        ShellKind::Posix
+    }
+}
+
+fn quote_posix_command(command: &[String]) -> String {
+    command
+        .iter()
+        .map(|arg| {
+            if arg.is_empty() {
+                "''".to_string()
+            } else {
+                format!("'{}'", arg.replace('\'', "'\"'\"'"))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn quote_powershell_command(command: &[String]) -> String {
+    let mut parts = command.iter();
+    let Some(program) = parts.next() else {
+        return String::new();
+    };
+
+    let mut rendered = format!("& '{}'", program.replace('\'', "''"));
+    for arg in parts {
+        rendered.push(' ');
+        rendered.push_str(&format!("'{}'", arg.replace('\'', "''")));
+    }
+    rendered
+}
+
+fn quote_cmd_command(command: &[String]) -> String {
+    command
+        .iter()
+        .map(|arg| {
+            if arg.is_empty() {
+                "\"\"".to_string()
+            } else if arg.chars().any(|c| c.is_whitespace() || matches!(c, '&' | '|' | '<' | '>' | '^' | '"')) {
+                format!("\"{}\"", arg.replace('"', "\\\""))
+            } else {
+                arg.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Run a client command by connecting to the daemon.
 fn run_client_command(cli: Cli) -> anyhow::Result<()> {
     // Handle commands that don't need daemon communication
-    let Some(command) = cli_to_command(&cli) else {
+    let Some(command) = cli_to_command(&cli)? else {
         // Examples command just prints and exits
         if let Commands::Examples = cli.command {
             println!("{}", crate::args::EXAMPLES_TEXT);

--- a/crates/pilotty-cli/src/main.rs
+++ b/crates/pilotty-cli/src/main.rs
@@ -183,7 +183,7 @@ fn run_daemon() {
                     std::process::exit(1);
                 }
             }
-            _ = tokio::signal::ctrl_c() => {
+            _ = ctrl_c_signal() => {
                 info!("Received SIGINT, shutting down gracefully");
             }
             _ = sigterm() => {
@@ -192,6 +192,24 @@ fn run_daemon() {
         }
         // Server is dropped here, triggering cleanup of socket and PID files
     });
+}
+
+/// Wait for SIGINT / Ctrl+C.
+///
+/// On Windows the auto-started daemon runs detached without a console, so listening
+/// for Ctrl+C can cause premature shutdown. Detached daemons are stopped via the
+/// explicit `pilotty stop` command instead.
+#[cfg(unix)]
+async fn ctrl_c_signal() {
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        tracing::warn!("Failed to register SIGINT handler: {}", e);
+        std::future::pending::<()>().await;
+    }
+}
+
+#[cfg(windows)]
+async fn ctrl_c_signal() {
+    std::future::pending::<()>().await;
 }
 
 /// Wait for SIGTERM signal (Unix only).

--- a/npm/bin/pilotty.js
+++ b/npm/bin/pilotty.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+const { existsSync } = require('node:fs');
+const { join } = require('node:path');
+const { spawn } = require('node:child_process');
+
+const osMap = {
+  darwin: 'darwin',
+  linux: 'linux',
+  win32: 'win32',
+};
+
+const archMap = {
+  x64: 'x64',
+  arm64: 'arm64',
+};
+
+const os = osMap[process.platform];
+const arch = archMap[process.arch];
+
+if (!os) {
+  console.error(`Error: Unsupported operating system: ${process.platform}`);
+  console.error('pilotty supports macOS, Linux, and Windows.');
+  process.exit(1);
+}
+
+if (!arch) {
+  console.error(`Error: Unsupported architecture: ${process.arch}`);
+  console.error('pilotty supports x64 and arm64 architectures.');
+  process.exit(1);
+}
+
+const extension = os === 'win32' ? '.exe' : '';
+const binary = join(__dirname, `pilotty-${os}-${arch}${extension}`);
+
+if (!existsSync(binary)) {
+  console.error(`Error: No binary found for ${os}-${arch}`);
+  console.error(`Expected: ${binary}`);
+  console.error('You can build from source: https://github.com/msmps/pilotty');
+  process.exit(1);
+}
+
+const child = spawn(binary, process.argv.slice(2), {
+  stdio: 'inherit',
+  windowsHide: true,
+});
+
+child.on('error', (error) => {
+  console.error(`Failed to launch pilotty: ${error.message}`);
+  process.exit(1);
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -22,14 +22,15 @@
     "url": "https://github.com/msmps/pilotty/issues"
   },
   "bin": {
-    "pilotty": "./bin/pilotty"
+    "pilotty": "./bin/pilotty.js"
   },
   "files": [
     "bin"
   ],
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "cpu": [
     "x64",


### PR DESCRIPTION
## Summary
- add Windows daemon/client transport support
- add a Windows process-backed session fallback so pilotty can run on Windows
- update CI, release packaging, npm launcher, and docs for Windows builds

## Verification
- cargo test
- cargo build --release
- verified pilotty.exe runs on Windows and can spawn, snapshot, and send input

## Notes
- Windows support is documented as experimental for full-screen TUI parity
