### PR TITLE
chore: foundation housekeeping — fix skill docs, drop unused termwiz, ignore internal tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ target/
 .env
 .env.local
 
+# Reference clones for competitive auditing
+.repos/
+
 # Agent/AI tooling
 .opencode/
 .claude/
@@ -24,6 +27,7 @@ AGENTS.md
 
 # Internal docs (not for public repo)
 docs/
+specs/
 TODO*.md
 
 # Examples (local dev only)
@@ -32,3 +36,4 @@ examples/
 # npm - binaries are downloaded during release
 npm/bin/pilotty-*
 npm/node_modules/
+.overseer/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,65 @@
+# pilotty
+
+Terminal automation for AI agents: a daemon manages PTY-backed sessions so that agents
+can run, observe, and operate interactive TUI applications through a CLI.
+
+## Language
+
+### Sessions and lifecycle
+
+**Session**:
+A PTY-backed process the daemon is currently running and emulating, addressed by id or name.
+_Avoid_: pane, tab, terminal (for the managed thing itself)
+
+**Tombstone**:
+A bounded, short-lived record of an ended session: exit metadata plus final evidence.
+Not a session; never counts toward session limits.
+_Avoid_: dead session, session history
+
+**Exited**:
+The state of a session whose process has ended but whose tombstone is still available.
+_Avoid_: killed (reserve for explicit `kill`), dead
+
+**Expired**:
+An ended session whose tombstone is gone (TTL, eviction, or daemon restart);
+indistinguishable from never-existed.
+
+### Observation
+
+**Snapshot**:
+A point-in-time capture of a session's current screen, optionally with detected elements.
+_Avoid_: frame, capture (as a noun)
+
+**Element**:
+A UI control detected on the screen (button, input, toggle) with its position and label.
+_Avoid_: widget, component
+
+**Revision**:
+A monotonic per-session counter that advances whenever screen state may have changed;
+the identity used for change detection and future diffs.
+_Avoid_: version (reserved for protocol/releases), generation
+
+**Settled**:
+Screen content unchanged for the requested quiet window. A property of the *screen*.
+_Avoid_: stable, quiet
+
+**Idle**:
+No output from the session's process for some duration. A property of the *process* —
+a screen can be settled while the process is busy, and output can arrive without
+visibly changing the screen.
+
+**Capture outcome**:
+Why a waited snapshot returned: `settled`, `changed`, `deadline`, or `exited`.
+_Avoid_: capture reason
+
+### Evidence
+
+**Retention ring**:
+The bounded in-memory buffer of a session's most recent raw output bytes, served by
+`logs`. Always on, always bounded, truncation always reported.
+_Avoid_: scrollback (the emulator concept), log file
+
+**Recording**:
+An opt-in, append-only file of everything a session emitted over time, replayable later.
+Distinct from the retention ring, which is bounded and in-memory.
+_Avoid_: cast (that is the export format), tape

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ serde_json = "1"
 portable-pty = "0.9"
 
 # Terminal emulation
-termwiz = "0.23"
 vt100 = "0.16"
 
 # Utilities

--- a/skills/pilotty/SKILL.md
+++ b/skills/pilotty/SKILL.md
@@ -57,7 +57,7 @@ pilotty kill                      # Kill default session
 pilotty kill -s myapp             # Kill specific session
 pilotty list-sessions             # List all active sessions
 pilotty daemon                    # Manually start daemon (usually auto-starts)
-pilotty shutdown                  # Stop daemon and all sessions
+pilotty stop                      # Stop daemon and all sessions
 pilotty examples                  # Show end-to-end workflow example
 ```
 


### PR DESCRIPTION
## Summary

Housekeeping batch ahead of the v0.0.8 feature work:

- **`skills/pilotty/SKILL.md`**: documented `pilotty shutdown`, which doesn't exist — the real subcommand is `pilotty stop`. Agents following the skill hit a hard error on the last step of the documented workflow.
- **`Cargo.toml`**: remove `termwiz` from `workspace.dependencies` — declared but used by no crate (it never appears in `Cargo.lock`).
- **`.gitignore`**: cover reference clones (`.repos/`), agent tooling (`.claude/`, `.opencode/`, `.agents/`, `AGENTS.md`), and internal docs (`docs/`, `specs/`, `TODO*.md`, `examples/`). None of these were tracked; this prevents future accidents.
- **`CONTEXT.md`** (new): a short public glossary pinning the project's vocabulary — session / tombstone / expired, settled (screen) vs idle (process), revision, retention ring vs recording — ahead of upcoming features that introduce these terms into the CLI surface.

## Verification

- Full test suite: 176 passed, 0 failed on both crates.
- `Cargo.lock` unchanged by the termwiz removal.
- `grep -r "pilotty shutdown"` — no remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)