### PR TITLE
feat(protocol): version the daemon wire protocol

### DIFF
--- a/crates/pilotty-cli/src/daemon/client.rs
+++ b/crates/pilotty-cli/src/daemon/client.rs
@@ -5,7 +5,7 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
-use pilotty_core::protocol::{Request, Response};
+use pilotty_core::protocol::{Request, Response, PROTOCOL_VERSION};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::time::timeout;
@@ -155,6 +155,15 @@ impl DaemonClient {
 
         let response: Response =
             serde_json::from_str(&response_line).context("Failed to parse response")?;
+
+        if response.protocol < PROTOCOL_VERSION {
+            eprintln!(
+                "warning: the running daemon speaks protocol {} but this client speaks {}; \
+                 run 'pilotty stop' so the daemon restarts with the current binary",
+                response.protocol, PROTOCOL_VERSION
+            );
+        }
+
         Ok(response)
     }
 }
@@ -163,7 +172,7 @@ impl DaemonClient {
 mod tests {
     use super::*;
     use crate::daemon::server::DaemonServer;
-    use pilotty_core::protocol::Command;
+    use pilotty_core::protocol::{Command, PROTOCOL_VERSION};
 
     #[tokio::test]
     async fn test_client_connects_to_running_daemon() {
@@ -192,6 +201,7 @@ mod tests {
 
         // Send request
         let request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "client-test-1".to_string(),
             command: Command::ListSessions,
         };

--- a/crates/pilotty-cli/src/daemon/server.rs
+++ b/crates/pilotty-cli/src/daemon/server.rs
@@ -1308,7 +1308,7 @@ async fn handle_shutdown(
 mod tests {
     use super::*;
     use pilotty_core::error::ErrorCode;
-    use pilotty_core::protocol::Command;
+    use pilotty_core::protocol::{Command, PROTOCOL_VERSION};
     use std::time::Duration;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     use tokio::net::UnixStream;
@@ -1344,6 +1344,7 @@ mod tests {
 
         // Send a request
         let request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "test-1".to_string(),
             command: Command::ListSessions,
         };
@@ -1436,6 +1437,7 @@ mod tests {
         let mut reader = BufReader::new(reader);
 
         let request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "scroll-1".to_string(),
             command: Command::Scroll {
                 direction: pilotty_core::protocol::ScrollDirection::Down,
@@ -1494,6 +1496,7 @@ mod tests {
 
         // Spawn a session running echo
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["echo".to_string(), "hello from test".to_string()],
@@ -1525,6 +1528,7 @@ mod tests {
 
         // Take a snapshot
         let snap_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "snap-1".to_string(),
             command: Command::Snapshot {
                 session: Some("test-snap".to_string()),
@@ -1600,6 +1604,7 @@ mod tests {
 
         // Spawn a session
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["echo".to_string(), "full format test".to_string()],
@@ -1625,6 +1630,7 @@ mod tests {
 
         // Request snapshot with Full format
         let snap_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "snap-full".to_string(),
             command: Command::Snapshot {
                 session: Some("full-test".to_string()),
@@ -1717,6 +1723,7 @@ mod tests {
 
         // Spawn a cat session (echoes input)
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["cat".to_string()],
@@ -1746,6 +1753,7 @@ mod tests {
 
         // Type some text
         let type_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "type-1".to_string(),
             command: Command::Type {
                 text: "Hello World".to_string(),
@@ -1772,6 +1780,7 @@ mod tests {
 
         // Take a snapshot and verify the text appears
         let snap_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "snap-1".to_string(),
             command: Command::Snapshot {
                 session: Some("type-test".to_string()),
@@ -1835,6 +1844,7 @@ mod tests {
 
         // Spawn a cat session
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["cat".to_string()],
@@ -1860,6 +1870,7 @@ mod tests {
 
         // Send a key
         let key_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "key-1".to_string(),
             command: Command::Key {
                 key: "Enter".to_string(),
@@ -1884,6 +1895,7 @@ mod tests {
 
         // Test Ctrl+C (which will terminate cat)
         let ctrlc_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "key-2".to_string(),
             command: Command::Key {
                 key: "Ctrl+C".to_string(),
@@ -1938,6 +1950,7 @@ mod tests {
 
         // Try to send a key with delay exceeding MAX_KEY_DELAY_MS (10000)
         let request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "key-delay-1".to_string(),
             command: Command::Key {
                 key: "a b".to_string(),
@@ -1994,6 +2007,7 @@ mod tests {
 
         // Spawn a session
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["cat".to_string()],
@@ -2019,6 +2033,7 @@ mod tests {
 
         // Click at coordinates (row 5, col 10)
         let click_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "click-1".to_string(),
             command: Command::Click {
                 row: 5,
@@ -2089,6 +2104,7 @@ mod tests {
 
         // Spawn a session
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["cat".to_string()],
@@ -2114,6 +2130,7 @@ mod tests {
 
         // Scroll up
         let scroll_up_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "scroll-1".to_string(),
             command: Command::Scroll {
                 direction: ScrollDirection::Up,
@@ -2141,6 +2158,7 @@ mod tests {
 
         // Scroll down
         let scroll_down_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "scroll-2".to_string(),
             command: Command::Scroll {
                 direction: ScrollDirection::Down,
@@ -2194,6 +2212,7 @@ mod tests {
 
         // Spawn a session that outputs text
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["echo".to_string(), "hello world marker".to_string()],
@@ -2220,6 +2239,7 @@ mod tests {
 
         // Wait for the text
         let wait_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "wait-1".to_string(),
             command: Command::WaitFor {
                 pattern: "marker".to_string(),
@@ -2285,6 +2305,7 @@ mod tests {
 
         // Spawn a session
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["echo".to_string(), "version 1.2.3 ready".to_string()],
@@ -2310,6 +2331,7 @@ mod tests {
 
         // Wait for regex pattern (version number)
         let wait_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "wait-re".to_string(),
             command: Command::WaitFor {
                 pattern: r"version \d+\.\d+\.\d+".to_string(),
@@ -2375,6 +2397,7 @@ mod tests {
         // We need a process that stays alive so the session isn't cleaned up
         // before the wait-for timeout occurs.
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["cat".to_string()],
@@ -2400,6 +2423,7 @@ mod tests {
 
         // Wait for text that won't appear (short timeout)
         let wait_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "wait-to".to_string(),
             command: Command::WaitFor {
                 pattern: "nonexistent pattern xyz".to_string(),
@@ -2463,6 +2487,7 @@ mod tests {
 
         // Spawn a session
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["echo".to_string(), "test".to_string()],
@@ -2486,6 +2511,7 @@ mod tests {
 
         // Try invalid regex
         let wait_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "wait-bad".to_string(),
             command: Command::WaitFor {
                 pattern: "[invalid(regex".to_string(), // Unbalanced brackets
@@ -2552,6 +2578,7 @@ mod tests {
 
         // Spawn cat (echoes input)
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["cat".to_string()],
@@ -2577,6 +2604,7 @@ mod tests {
 
         // Take baseline snapshot to get initial hash
         let snap_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "snap-baseline".to_string(),
             command: Command::Snapshot {
                 session: Some("await-test".to_string()),
@@ -2611,6 +2639,7 @@ mod tests {
 
         // Type something to change the screen
         let type_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "type-1".to_string(),
             command: Command::Type {
                 text: "hello".to_string(),
@@ -2631,6 +2660,7 @@ mod tests {
         // Request snapshot with await_change - should detect the change
         let start = std::time::Instant::now();
         let await_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "snap-await".to_string(),
             command: Command::Snapshot {
                 session: Some("await-test".to_string()),
@@ -2716,6 +2746,7 @@ mod tests {
 
         // Spawn cat with no input: the screen stays empty and static
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec!["cat".to_string()],
@@ -2741,6 +2772,7 @@ mod tests {
 
         // Take baseline snapshot to get the current hash
         let snap_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "snap-baseline".to_string(),
             command: Command::Snapshot {
                 session: Some("await-static-test".to_string()),
@@ -2771,6 +2803,7 @@ mod tests {
         // Await a change that never comes: must time out, not return instantly
         let start = std::time::Instant::now();
         let await_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "snap-await".to_string(),
             command: Command::Snapshot {
                 session: Some("await-static-test".to_string()),
@@ -2845,6 +2878,7 @@ mod tests {
 
         // Spawn a command that keeps changing the screen
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-1".to_string(),
             command: Command::Spawn {
                 command: vec![
@@ -2875,6 +2909,7 @@ mod tests {
         // Ask for a settled screen: it never settles, so this must time out
         let start = std::time::Instant::now();
         let settle_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "snap-settle".to_string(),
             command: Command::Snapshot {
                 session: Some("settle-busy-test".to_string()),
@@ -2945,6 +2980,7 @@ mod tests {
 
         // Try to spawn with nonexistent cwd
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-bad-cwd".to_string(),
             command: Command::Spawn {
                 command: vec!["pwd".to_string()],
@@ -3018,6 +3054,7 @@ mod tests {
         // - [OK] and [Cancel] → Buttons (bracket pattern, confidence 0.8)
         // - [x] and [ ] → Toggles (checkbox pattern, confidence 1.0)
         let spawn_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "spawn-elem".to_string(),
             command: Command::Spawn {
                 command: vec![
@@ -3047,6 +3084,7 @@ mod tests {
 
         // Request snapshot with Full format (includes elements)
         let snap_request = Request {
+            protocol: PROTOCOL_VERSION,
             id: "snap-elem".to_string(),
             command: Command::Snapshot {
                 session: Some("elem-test".to_string()),

--- a/crates/pilotty-cli/src/main.rs
+++ b/crates/pilotty-cli/src/main.rs
@@ -123,10 +123,7 @@ fn run_client_command(cli: Cli) -> anyhow::Result<()> {
         let mut client = DaemonClient::connect().await?;
 
         // Build request
-        let request = Request {
-            id: Uuid::new_v4().to_string(),
-            command,
-        };
+        let request = Request::new(Uuid::new_v4().to_string(), command);
 
         // Send request and get response
         let response = client.request(request).await?;

--- a/crates/pilotty-core/src/protocol.rs
+++ b/crates/pilotty-core/src/protocol.rs
@@ -10,11 +10,34 @@ fn default_snapshot_timeout() -> u64 {
     30000
 }
 
+/// Current daemon protocol version.
+///
+/// Carried on every `Request` and `Response` so a client and an
+/// already-running daemon can detect version skew (e.g. mid-upgrade).
+/// Messages from binaries that predate versioning deserialize as version 0
+/// via `#[serde(default)]`. Bump when a change is incompatible; additive
+/// fields and enum variants do not require a bump on their own, but a client
+/// must treat a lower daemon version as "this command may not exist yet".
+pub const PROTOCOL_VERSION: u32 = 1;
+
 /// A request from CLI to daemon.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Request {
     pub id: String,
     pub command: Command,
+    /// Protocol version spoken by the client. 0 = predates versioning.
+    #[serde(default)]
+    pub protocol: u32,
+}
+
+impl Request {
+    pub fn new(id: impl Into<String>, command: Command) -> Self {
+        Self {
+            id: id.into(),
+            command,
+            protocol: PROTOCOL_VERSION,
+        }
+    }
 }
 
 /// Commands the daemon can execute.
@@ -128,6 +151,9 @@ pub struct Response {
     pub data: Option<ResponseData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<ApiError>,
+    /// Protocol version spoken by the daemon. 0 = predates versioning.
+    #[serde(default)]
+    pub protocol: u32,
 }
 
 impl Response {
@@ -137,6 +163,7 @@ impl Response {
             success: true,
             data: Some(data),
             error: None,
+            protocol: PROTOCOL_VERSION,
         }
     }
 
@@ -146,6 +173,7 @@ impl Response {
             success: false,
             data: None,
             error: Some(error),
+            protocol: PROTOCOL_VERSION,
         }
     }
 }
@@ -182,4 +210,58 @@ pub struct SessionInfo {
     pub name: Option<String>,
     pub command: Vec<String>,
     pub created_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_serializes_with_protocol_version() {
+        let request = Request::new("req-1", Command::ListSessions);
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"protocol\":1"), "got: {json}");
+    }
+
+    #[test]
+    fn legacy_request_without_protocol_deserializes_as_version_zero() {
+        // Wire format sent by clients that predate protocol versioning.
+        let json = r#"{"id":"req-1","command":{"action":"list_sessions"}}"#;
+        let request: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(request.protocol, 0);
+        assert_eq!(request.id, "req-1");
+    }
+
+    #[test]
+    fn legacy_daemon_ignores_unknown_protocol_field() {
+        // A current client's request must still parse if a field is unknown
+        // to the receiver; serde ignores unknown fields by default. Guard
+        // against someone adding deny_unknown_fields later.
+        let json = r#"{"id":"req-1","command":{"action":"list_sessions"},"protocol":1,"future_field":true}"#;
+        let request: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(request.protocol, 1);
+    }
+
+    #[test]
+    fn response_constructors_set_protocol_version() {
+        let ok = Response::success(
+            "req-1",
+            ResponseData::Ok {
+                message: "done".to_string(),
+            },
+        );
+        assert_eq!(ok.protocol, PROTOCOL_VERSION);
+
+        let err = Response::error("req-2", ApiError::session_not_found("nope"));
+        assert_eq!(err.protocol, PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn legacy_response_without_protocol_deserializes_as_version_zero() {
+        // Wire format sent by daemons that predate protocol versioning:
+        // the client uses version 0 to detect a stale running daemon.
+        let json = r#"{"id":"req-1","success":true}"#;
+        let response: Response = serde_json::from_str(json).unwrap();
+        assert_eq!(response.protocol, 0);
+    }
 }


### PR DESCRIPTION
## Summary

Adds protocol versioning to the client↔daemon wire protocol, piggybacked on every message rather than a handshake roundtrip:

- `PROTOCOL_VERSION = 1`; `Request` and `Response` gain `protocol: u32` with `#[serde(default)]`, so messages from binaries that predate versioning deserialize as version 0.
- `Request::new()` stamps the client version; both `Response` constructors stamp the daemon version.
- The client warns on stderr when the running daemon speaks an older protocol, with the actionable fix: `run 'pilotty stop' so the daemon restarts with the current binary` (auto-start then spawns the new one).

**Why piggybacked instead of a hello/ack:** the only realistic mismatch is version skew with an already-running daemon (mid-upgrade). Additive JSON fields detect that for free; a handshake would add a roundtrip to every thin-client invocation to negotiate something that almost never fails.

**Why warning-only:** every current command exists in version 0, so nothing needs hard gating yet. Commands introduced at version 1+ will check the field and error helpfully when the daemon is older.

## Compatibility

- New client → old daemon: unknown `protocol` field ignored (guard test prevents `deny_unknown_fields` regressions).
- Old client → new daemon: missing field parses as 0; all v0 commands answer normally.
- Wire cost: +14 bytes per message.

## Tests

Five new wire-compat tests in `protocol.rs` covering both skew directions and constructor stamping. Full suite: 181 passed, 0 failed; clippy clean under `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)