### PR TITLE
fix(daemon): don't touch the env-derived socket dir when binding to explicit paths

### DIFF
--- a/crates/pilotty-cli/src/daemon/server.rs
+++ b/crates/pilotty-cli/src/daemon/server.rs
@@ -45,6 +45,10 @@ pub struct DaemonServer {
 impl DaemonServer {
     /// Create a new daemon server bound to the default socket path.
     pub async fn bind() -> Result<Self> {
+        // The default socket directory is derived from the environment and
+        // needs 0700 permissions; explicit-path binds (bind_to) must not
+        // touch it, so it is prepared here rather than in bind_to.
+        paths::ensure_socket_dir().context("Failed to create socket directory")?;
         let socket_path = paths::get_socket_path(None);
         let pid_path = paths::get_pid_path(None);
         Self::bind_to(socket_path, pid_path).await
@@ -58,9 +62,6 @@ impl DaemonServer {
     /// 3. If daemon dead, remove stale socket and retry
     /// 4. If daemon alive, return error
     pub async fn bind_to(socket_path: PathBuf, pid_path: PathBuf) -> Result<Self> {
-        // Ensure socket directory exists with secure permissions (0700)
-        paths::ensure_socket_dir().context("Failed to create socket directory")?;
-
         if let Some(parent) = socket_path.parent() {
             std::fs::create_dir_all(parent).with_context(|| {
                 format!("Failed to create socket directory for {:?}", socket_path)


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure in `test_client_connects_to_running_daemon` (seen on ubuntu in the #14 run and on macos on the v0.0.8 bump commit, run 29156160576):

```
Failed to bind server: Failed to create socket directory
Caused by: Read-only file system (os error 30)
```

## Root cause

`bind_to()` unconditionally called `paths::ensure_socket_dir()`, which resolves the **global** socket directory from `PILOTTY_SOCKET_DIR` → `XDG_RUNTIME_DIR` → `HOME` → tempdir. The paths tests mutate those exact env vars, serialized by a mutex — but only against *each other*. Env vars are process-global, so daemon/client tests running in parallel could observe a mid-test poisoned value and try to create a directory on an unwritable path.

## Fix

`bind_to()` receives explicit paths and already creates the socket's parent directory two lines later — the env-derived global dir was never its business. Preparing that directory (with 0700) moves to `bind()`, the production entry point that derives paths from the environment. `bind_to` now has zero dependency on global env state, which removes the race structurally rather than tuning test ordering.

No production behavior change: `bind()` still prepares the default directory before delegating.

## Verification

Five consecutive full-suite runs green locally; clippy clean under `-D warnings`; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)